### PR TITLE
feat: R-1 Zustand ストア分割 + テスト基盤導入

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,9 @@
         "zustand": "^4.5.2"
       },
       "devDependencies": {
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/cytoscape": "^3.21.4",
         "@types/jsonld": "^1.5.14",
         "@types/n3": "^1.16.4",
@@ -27,11 +30,25 @@
         "@types/react-dom": "^18.2.22",
         "@vitejs/plugin-react": "^4.2.1",
         "autoprefixer": "^10.4.19",
+        "jsdom": "^28.1.0",
         "postcss": "^8.4.38",
         "tailwindcss": "^3.4.1",
         "typescript": "^5.4.2",
-        "vite": "^5.2.0"
+        "vite": "^5.2.0",
+        "vitest": "^4.0.18"
       }
+    },
+    "node_modules/@acemir/cssom": {
+      "version": "0.9.31",
+      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+      "dev": true
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -45,6 +62,59 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.0.1.tgz",
+      "integrity": "sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw==",
+      "dev": true,
+      "dependencies": {
+        "@csstools/css-calc": "^3.1.1",
+        "@csstools/css-color-parser": "^4.0.2",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "dev": true,
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+      "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+      "dev": true,
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.6"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "dev": true,
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -280,6 +350,15 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -326,6 +405,144 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
+      "integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.0.tgz",
+      "integrity": "sha512-H4tuz2nhWgNKLt1inYpoVCfbJbMwX/lQKp3g69rrrIMIYlFD9+zTykOKhNR8uGrAmbS/kT9n6hTFkmDkxLgeTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ]
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@digitalbazaar/http-client": {
@@ -631,6 +848,22 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
@@ -648,6 +881,22 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
@@ -663,6 +912,22 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
@@ -731,6 +996,23 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@fastify/busboy": {
@@ -1220,6 +1502,104 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1265,12 +1645,28 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/cytoscape": {
       "version": "3.21.9",
       "resolved": "https://registry.npmjs.org/@types/cytoscape/-/cytoscape-3.21.9.tgz",
       "integrity": "sha512-JyrG4tllI6jvuISPjHK9j2Xv/LTbnLekLke5otGStjFluIyA9JjgnvgZrSBsp8cEDpiTjwgZUZwpPv8TSBcoLw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1356,6 +1752,84 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
+      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "dev": true,
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "dev": true,
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
+      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "4.0.18",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
+      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
+      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "dev": true,
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -1366,6 +1840,38 @@
       },
       "engines": {
         "node": ">=6.5"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/any-promise": {
@@ -1395,6 +1901,24 @@
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/autoprefixer": {
       "version": "10.4.27",
@@ -1464,6 +1988,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/binary-extensions": {
@@ -1587,6 +2120,15 @@
       "integrity": "sha512-0CNTVCLZggSh7bc5VkX5WWPWO+cyZbNd07IHIsSXLia/eAq+r836hgk+8BKoEh7949Mda87VUOitx5OddVj64A==",
       "license": "Apache-2.0"
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -1651,6 +2193,25 @@
         "layout-base": "^1.0.0"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -1662,6 +2223,30 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-6.2.0.tgz",
+      "integrity": "sha512-Fm5NvhYathRnXNVndkUsCCuR63DCLVVwGOOwQw782coXFi5HhkXdu289l59HlXZBawsyNccXfWRYvLzcDCdDig==",
+      "dev": true,
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.0.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.28",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.6"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cssstyle/node_modules/lru-cache": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "dev": true,
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/csstype": {
@@ -1701,6 +2286,19 @@
         "node": ">= 12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1719,6 +2317,21 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/didyoumean": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
@@ -1733,12 +2346,37 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.307",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.307.tgz",
       "integrity": "sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -1789,6 +2427,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
@@ -1805,6 +2452,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-glob": {
@@ -1970,6 +2626,44 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -1989,6 +2683,15 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -2052,6 +2755,12 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true
+    },
     "node_modules/jiti": {
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
@@ -2067,6 +2776,55 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "28.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.1.0.tgz",
+      "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
+      "dev": true,
+      "dependencies": {
+        "@acemir/cssom": "^0.9.31",
+        "@asamuzakjp/dom-selector": "^6.8.1",
+        "@bramus/specificity": "^2.4.2",
+        "@exodus/bytes": "^1.11.0",
+        "cssstyle": "^6.0.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "undici": "^7.21.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/undici": {
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
+      "integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
+      "dev": true,
+      "engines": {
+        "node": ">=20.18.1"
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -2221,6 +2979,31 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -2243,6 +3026,15 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/monaco-editor": {
@@ -2377,12 +3169,40 @@
         "node": ">= 6"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ]
+    },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -2587,6 +3407,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
     "node_modules/process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -2594,6 +3429,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/queue-microtask": {
@@ -2654,6 +3498,13 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -2701,6 +3552,28 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve": {
@@ -2824,6 +3697,18 @@
       ],
       "license": "MIT"
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -2849,6 +3734,12 @@
       "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
       "license": "MIT"
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2859,11 +3750,23 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
     "node_modules/state-local": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
       "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==",
       "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -2872,6 +3775,18 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/sucrase": {
@@ -2909,6 +3824,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true
     },
     "node_modules/tailwindcss": {
       "version": "3.4.19",
@@ -2971,6 +3892,21 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -3019,6 +3955,33 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.25.tgz",
+      "integrity": "sha512-keinCnPbwXEUG3ilrWQZU+CqcTTzHq9m2HhoUP2l7Xmi8l1LuijAXLpAJ5zRW+ifKTNscs4NdCkfkDCBYm352w==",
+      "dev": true,
+      "dependencies": {
+        "tldts-core": "^7.0.25"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.25.tgz",
+      "integrity": "sha512-ZjCZK0rppSBu7rjHYDYsEaMOIbbT+nWF57hKkv4IUmZWBNrBWBOjIElc0mKRgLM8bm7x/BBlof6t2gi/Oq/Asw==",
+      "dev": true
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -3030,6 +3993,30 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
+      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+      "dev": true,
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-interface-checker": {
@@ -3179,6 +4166,633 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
+      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/expect": "4.0.18",
+        "@vitest/mocker": "4.0.18",
+        "@vitest/pretty-format": "4.0.18",
+        "@vitest/runner": "4.0.18",
+        "@vitest/snapshot": "4.0.18",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.18",
+        "@vitest/browser-preview": "4.0.18",
+        "@vitest/browser-webdriverio": "4.0.18",
+        "@vitest/ui": "4.0.18",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
+      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "4.0.18",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/vitest/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
@@ -3187,6 +4801,69 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest",
+    "test:run": "vitest run",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@monaco-editor/react": "^4.6.0",
@@ -21,6 +24,9 @@
     "zustand": "^4.5.2"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/cytoscape": "^3.21.4",
     "@types/jsonld": "^1.5.14",
     "@types/n3": "^1.16.4",
@@ -28,9 +34,11 @@
     "@types/react-dom": "^18.2.22",
     "@vitejs/plugin-react": "^4.2.1",
     "autoprefixer": "^10.4.19",
+    "jsdom": "^28.1.0",
     "postcss": "^8.4.38",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.4.2",
-    "vite": "^5.2.0"
+    "vite": "^5.2.0",
+    "vitest": "^4.0.18"
   }
 }

--- a/src/components/editor/TurtleEditor.tsx
+++ b/src/components/editor/TurtleEditor.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react'
 import Editor, { Monaco } from '@monaco-editor/react'
 import type * as MonacoEditor from 'monaco-editor'
-import { useAppStore } from '../../store/appStore'
+import { useRdfStore } from '../../store/rdfStore'
 
 /** Sentinel column used to highlight an error squiggle to end-of-line in Monaco. */
 const END_OF_LINE_COLUMN = 9999
@@ -97,10 +97,10 @@ function registerTurtleLanguage(monaco: Monaco) {
 }
 
 export default function TurtleEditor() {
-  const turtleText = useAppStore((s) => s.turtleText)
-  const setTurtleText = useAppStore((s) => s.setTurtleText)
-  const parseError = useAppStore((s) => s.parseError)
-  const isParsing = useAppStore((s) => s.isParsing)
+  const turtleText = useRdfStore((s) => s.turtleText)
+  const setTurtleText = useRdfStore((s) => s.setTurtleText)
+  const parseError = useRdfStore((s) => s.parseError)
+  const isParsing = useRdfStore((s) => s.isParsing)
   const editorRef = useRef<MonacoEditor.editor.IStandaloneCodeEditor | null>(null)
   const monacoRef = useRef<Monaco | null>(null)
 

--- a/src/components/graph/RdfGraph.tsx
+++ b/src/components/graph/RdfGraph.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useRef, useCallback } from 'react'
 import cytoscape from 'cytoscape'
 import coseBilkent from 'cytoscape-cose-bilkent'
-import { useAppStore } from '../../store/appStore'
+import { useRdfStore } from '../../store/rdfStore'
+import { useUiStore } from '../../store/uiStore'
 import { storeToCytoscape, CY_STYLE } from './graphUtils'
 
 cytoscape.use(coseBilkent)
@@ -10,10 +11,10 @@ export default function RdfGraph() {
   const containerRef = useRef<HTMLDivElement>(null)
   const cyRef = useRef<cytoscape.Core | null>(null)
 
-  const store = useAppStore((s) => s.store)
-  const prefixes = useAppStore((s) => s.prefixes)
-  const selectedNode = useAppStore((s) => s.selectedNode)
-  const setSelectedNode = useAppStore((s) => s.setSelectedNode)
+  const store = useRdfStore((s) => s.store)
+  const prefixes = useRdfStore((s) => s.prefixes)
+  const selectedNode = useUiStore((s) => s.selectedNode)
+  const setSelectedNode = useUiStore((s) => s.setSelectedNode)
 
   // Initialize cytoscape once
   useEffect(() => {

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -10,7 +10,9 @@ import {
   BookOpen,
   Layers,
 } from 'lucide-react'
-import { useAppStore, type ActiveView, type AppMode } from '../../store/appStore'
+import { useRdfStore } from '../../store/rdfStore'
+import { useUiStore, type ActiveView } from '../../store/uiStore'
+import { useDomainStore } from '../../store/domainStore'
 import TurtleEditor from '../editor/TurtleEditor'
 import RdfGraph from '../graph/RdfGraph'
 import TripleTable from '../table/TripleTable'
@@ -25,15 +27,22 @@ const VIEW_BUTTONS: { id: ActiveView; icon: React.ReactNode; label: string }[] =
 ]
 
 export default function AppLayout() {
-  const activeView = useAppStore((s) => s.activeView)
-  const mode = useAppStore((s) => s.mode)
-  const setActiveView = useAppStore((s) => s.setActiveView)
-  const setMode = useAppStore((s) => s.setMode)
-  const importFile = useAppStore((s) => s.importFile)
-  const exportAs = useAppStore((s) => s.exportAs)
-  const loadExample = useAppStore((s) => s.loadExample)
-  const clearAll = useAppStore((s) => s.clearAll)
+  const activeView = useUiStore((s) => s.activeView)
+  const setActiveView = useUiStore((s) => s.setActiveView)
+
+  const activeDomainId = useDomainStore((s) => s.activeDomainId)
+  const registeredDomains = useDomainStore((s) => s.registeredDomains)
+  const setActiveDomain = useDomainStore((s) => s.setActiveDomain)
+  const loadTemplate = useDomainStore((s) => s.loadTemplate)
+
+  const importFile = useRdfStore((s) => s.importFile)
+  const exportAs = useRdfStore((s) => s.exportAs)
+  const clearAll = useRdfStore((s) => s.clearAll)
+
   const fileInputRef = useRef<HTMLInputElement>(null)
+
+  // Convert Map to sorted array for rendering
+  const domainList = Array.from(registeredDomains.values())
 
   function handleFileOpen(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0]
@@ -55,7 +64,7 @@ export default function AppLayout() {
   }
 
   function renderMainContent() {
-    if (mode === 'samm') {
+    if (activeDomainId === 'samm') {
       return (
         <div className="flex h-full">
           <div className="w-1/2 border-r border-surface-raised overflow-hidden flex flex-col">
@@ -94,38 +103,36 @@ export default function AppLayout() {
           <span className="text-sm font-medium text-text-primary">RDF Editor</span>
         </div>
 
-        {/* Mode toggle */}
+        {/* Mode toggle — dynamically generated from registered domains */}
         <div className="flex rounded overflow-hidden border border-surface-raised mr-2">
-          {(['free', 'samm'] as AppMode[]).map((m) => (
+          {domainList.map((domain) => (
             <button
-              key={m}
-              onClick={() => setMode(m)}
-              className={`px-3 py-1 text-xs capitalize transition-colors ${
-                mode === m
-                  ? m === 'samm'
+              key={domain.id}
+              onClick={() => setActiveDomain(domain.id)}
+              className={`px-3 py-1 text-xs capitalize transition-colors ${activeDomainId === domain.id
+                  ? domain.id === 'samm'
                     ? 'bg-accent-purple text-surface font-medium'
                     : 'bg-accent-blue text-surface font-medium'
                   : 'text-text-muted hover:text-text-primary hover:bg-surface-raised'
-              }`}
+                }`}
             >
-              {m === 'samm' ? 'SAMM' : 'Free'}
+              {domain.label}
             </button>
           ))}
         </div>
 
         {/* View toggle (hidden in SAMM mode) */}
-        {mode !== 'samm' && (
+        {activeDomainId !== 'samm' && (
           <div className="flex rounded overflow-hidden border border-surface-raised mr-2">
             {VIEW_BUTTONS.map((btn) => (
               <button
                 key={btn.id}
                 onClick={() => setActiveView(btn.id)}
                 title={btn.label}
-                className={`px-2.5 py-1 flex items-center gap-1 text-xs transition-colors ${
-                  activeView === btn.id
+                className={`px-2.5 py-1 flex items-center gap-1 text-xs transition-colors ${activeView === btn.id
                     ? 'bg-surface-raised text-text-primary'
                     : 'text-text-muted hover:text-text-primary hover:bg-surface-raised'
-                }`}
+                  }`}
               >
                 {btn.icon}
                 <span className="hidden sm:inline">{btn.label}</span>
@@ -135,25 +142,24 @@ export default function AppLayout() {
         )}
 
         <div className="ml-auto flex items-center gap-1">
-          {/* Examples */}
+          {/* Examples — dynamically generated from registered domains */}
           <div className="relative group">
             <button className="flex items-center gap-1 px-2.5 py-1 text-xs text-text-muted hover:text-text-primary hover:bg-surface-raised rounded">
               <BookOpen size={13} />
               <span className="hidden sm:inline">Examples</span>
             </button>
             <div className="hidden group-hover:flex flex-col absolute right-0 top-full mt-1 bg-surface-raised border border-surface-raised rounded shadow-lg z-50 min-w-36">
-              <button
-                onClick={() => loadExample('foaf')}
-                className="px-3 py-2 text-xs text-left hover:bg-surface text-text-primary"
-              >
-                FOAF Graph
-              </button>
-              <button
-                onClick={() => { loadExample('samm'); setMode('samm') }}
-                className="px-3 py-2 text-xs text-left hover:bg-surface text-text-primary"
-              >
-                SAMM Aspect
-              </button>
+              {domainList.map((domain) =>
+                domain.templates.map((tmpl) => (
+                  <button
+                    key={`${domain.id}-${tmpl.id}`}
+                    onClick={() => loadTemplate(domain.id, tmpl.id)}
+                    className="px-3 py-2 text-xs text-left hover:bg-surface text-text-primary"
+                  >
+                    {tmpl.label}
+                  </button>
+                ))
+              )}
             </div>
           </div>
 

--- a/src/components/layout/StatusBar.tsx
+++ b/src/components/layout/StatusBar.tsx
@@ -1,20 +1,23 @@
-import { useAppStore } from '../../store/appStore'
+import { useRdfStore } from '../../store/rdfStore'
+import { useDomainStore } from '../../store/domainStore'
 
 export default function StatusBar() {
-  const store = useAppStore((s) => s.store)
-  const prefixes = useAppStore((s) => s.prefixes)
-  const parseError = useAppStore((s) => s.parseError)
-  const isParsing = useAppStore((s) => s.isParsing)
-  const mode = useAppStore((s) => s.mode)
+  const store = useRdfStore((s) => s.store)
+  const prefixes = useRdfStore((s) => s.prefixes)
+  const parseError = useRdfStore((s) => s.parseError)
+  const isParsing = useRdfStore((s) => s.isParsing)
+  const activeDomainId = useDomainStore((s) => s.activeDomainId)
+  const registeredDomains = useDomainStore((s) => s.registeredDomains)
 
   const prefixCount = Object.keys(prefixes).length
+  const domainLabel = registeredDomains.get(activeDomainId)?.label ?? activeDomainId
 
   return (
     <div className="flex items-center gap-4 px-4 py-1 border-t border-surface-raised text-[11px] text-text-muted bg-surface-alt">
       <span>
         Mode:{' '}
-        <span className={mode === 'samm' ? 'text-accent-purple' : 'text-accent-blue'}>
-          {mode === 'samm' ? 'SAMM' : 'Free'}
+        <span className={activeDomainId === 'samm' ? 'text-accent-purple' : 'text-accent-blue'}>
+          {domainLabel}
         </span>
       </span>
       <span>Triples: <span className="text-text-primary">{store.size}</span></span>

--- a/src/components/samm/AspectForm.tsx
+++ b/src/components/samm/AspectForm.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { Plus, ChevronDown, ChevronUp } from 'lucide-react'
 import type { SammAspect } from '../../types/rdf'
-import { useAppStore } from '../../store/appStore'
+import { useRdfStore } from '../../store/rdfStore'
 import { newPropertySnippet } from '../../lib/samm/templates'
 import { localName } from '../../lib/rdf/namespaces'
 import { SAMM_C } from '../../lib/samm/vocabulary'
@@ -29,8 +29,8 @@ function iriNamespace(iri: string) {
 }
 
 export default function AspectForm({ aspect }: Props) {
-  const turtleText = useAppStore((s) => s.turtleText)
-  const setTurtleText = useAppStore((s) => s.setTurtleText)
+  const turtleText = useRdfStore((s) => s.turtleText)
+  const setTurtleText = useRdfStore((s) => s.setTurtleText)
   const [showAddProp, setShowAddProp] = useState(false)
   const [propName, setPropName] = useState('')
   const [charIri, setCharIri] = useState(SAMM_C.Text)

--- a/src/components/samm/SammPanel.tsx
+++ b/src/components/samm/SammPanel.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react'
 import { Plus, ChevronRight, Box } from 'lucide-react'
-import { useAppStore } from '../../store/appStore'
+import { useRdfStore } from '../../store/rdfStore'
 import { findAspects, readAspect, findEntities, readEntity } from '../../lib/samm/reader'
 import { localName } from '../../lib/rdf/namespaces'
 import { newAspectTemplate } from '../../lib/samm/templates'
@@ -14,9 +14,9 @@ type Selection =
   | null
 
 export default function SammPanel() {
-  const store = useAppStore((s) => s.store)
-  const turtleText = useAppStore((s) => s.turtleText)
-  const setTurtleText = useAppStore((s) => s.setTurtleText)
+  const store = useRdfStore((s) => s.store)
+  const turtleText = useRdfStore((s) => s.turtleText)
+  const setTurtleText = useRdfStore((s) => s.setTurtleText)
   const [selected, setSelected] = useState<Selection>(null)
   const [showNewAspect, setShowNewAspect] = useState(false)
   const [newName, setNewName] = useState('')
@@ -66,9 +66,8 @@ export default function SammPanel() {
           <button
             key={iri}
             onClick={() => setSelected({ kind: 'aspect', iri })}
-            className={`flex items-center gap-1.5 px-3 py-1.5 w-full text-left hover:bg-surface-raised truncate ${
-              selected?.iri === iri ? 'bg-surface-raised text-accent-purple' : 'text-text-primary'
-            }`}
+            className={`flex items-center gap-1.5 px-3 py-1.5 w-full text-left hover:bg-surface-raised truncate ${selected?.iri === iri ? 'bg-surface-raised text-accent-purple' : 'text-text-primary'
+              }`}
           >
             <Box size={11} className="text-accent-purple shrink-0" />
             <span className="truncate">{localName(iri)}</span>
@@ -86,9 +85,8 @@ export default function SammPanel() {
               <button
                 key={iri}
                 onClick={() => setSelected({ kind: 'entity', iri })}
-                className={`flex items-center gap-1.5 px-3 py-1.5 w-full text-left hover:bg-surface-raised truncate ${
-                  selected?.iri === iri ? 'bg-surface-raised text-accent-cyan' : 'text-text-primary'
-                }`}
+                className={`flex items-center gap-1.5 px-3 py-1.5 w-full text-left hover:bg-surface-raised truncate ${selected?.iri === iri ? 'bg-surface-raised text-accent-cyan' : 'text-text-primary'
+                  }`}
               >
                 <span className="text-accent-cyan font-bold">E</span>
                 <span className="truncate">{localName(iri)}</span>

--- a/src/components/table/TripleTable.tsx
+++ b/src/components/table/TripleTable.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react'
-import { useAppStore } from '../../store/appStore'
+import { useRdfStore } from '../../store/rdfStore'
+import { useUiStore } from '../../store/uiStore'
 import { storeToTriples } from '../../lib/rdf/store'
 import { shorten } from '../../lib/rdf/namespaces'
 import type { Triple } from '../../types/rdf'
@@ -8,9 +9,9 @@ import { Search } from 'lucide-react'
 const PAGE_SIZE = 100
 
 export default function TripleTable() {
-  const store = useAppStore((s) => s.store)
-  const prefixes = useAppStore((s) => s.prefixes)
-  const setSelectedNode = useAppStore((s) => s.setSelectedNode)
+  const store = useRdfStore((s) => s.store)
+  const prefixes = useRdfStore((s) => s.prefixes)
+  const setSelectedNode = useUiStore((s) => s.setSelectedNode)
   const [filter, setFilter] = useState('')
   const [page, setPage] = useState(0)
 

--- a/src/lib/rdf/__tests__/namespaces.test.ts
+++ b/src/lib/rdf/__tests__/namespaces.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest'
+import { shorten, localName, prefixDeclarations } from '../namespaces'
+
+describe('shorten', () => {
+    it('shortens known namespace IRIs', () => {
+        expect(shorten('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'))
+            .toBe('rdf:type')
+        expect(shorten('http://xmlns.com/foaf/0.1/Person'))
+            .toBe('foaf:Person')
+        expect(shorten('http://www.w3.org/2000/01/rdf-schema#label'))
+            .toBe('rdfs:label')
+    })
+
+    it('uses extra prefixes with priority', () => {
+        const extra = { ex: 'http://example.org/' }
+        expect(shorten('http://example.org/alice', extra))
+            .toBe('ex:alice')
+    })
+
+    it('falls back to local name after # or /', () => {
+        expect(shorten('http://unknown.org/vocab#Widget'))
+            .toBe('Widget')
+        expect(shorten('http://unknown.org/vocab/Widget'))
+            .toBe('Widget')
+    })
+
+    it('returns original IRI when no # or / separator found', () => {
+        // urn:uuid:12345 has ':' separators but no '#' or '/' after the scheme
+        // shorten correctly returns the full IRI
+        expect(shorten('urn:uuid:12345')).toBe('urn:uuid:12345')
+    })
+})
+
+describe('localName', () => {
+    it('extracts local name after #', () => {
+        expect(localName('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'))
+            .toBe('type')
+    })
+
+    it('extracts local name after /', () => {
+        expect(localName('http://xmlns.com/foaf/0.1/Person'))
+            .toBe('Person')
+    })
+
+    it('returns full IRI when no separator', () => {
+        expect(localName('foobar')).toBe('foobar')
+    })
+})
+
+describe('prefixDeclarations', () => {
+    it('generates @prefix lines', () => {
+        const decls = prefixDeclarations()
+        expect(decls).toContain('@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .')
+        expect(decls).toContain('@prefix foaf: <http://xmlns.com/foaf/0.1/> .')
+    })
+
+    it('includes extra prefixes', () => {
+        const decls = prefixDeclarations({ ex: 'http://example.org/' })
+        expect(decls).toContain('@prefix ex: <http://example.org/> .')
+    })
+})

--- a/src/lib/rdf/__tests__/parser.test.ts
+++ b/src/lib/rdf/__tests__/parser.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest'
+import { parseTurtle, parseNTriples, parseJsonLd, parseAuto } from '../parser'
+
+const VALID_TURTLE = `
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://example.org/alice> a foaf:Person ;
+    foaf:name "Alice" ;
+    foaf:age 30 .
+`
+
+const INVALID_TURTLE = `
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+<http://example.org/alice> foaf:name "Alice
+`
+
+const VALID_NTRIPLES = `<http://example.org/alice> <http://xmlns.com/foaf/0.1/name> "Alice" .
+<http://example.org/alice> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person> .
+`
+
+describe('parseTurtle', () => {
+    it('parses valid Turtle and returns store + prefixes', async () => {
+        const result = await parseTurtle(VALID_TURTLE)
+        expect(result.error).toBeUndefined()
+        expect(result.store.size).toBe(3) // alice a Person, name, age
+        expect(result.prefixes).toHaveProperty('foaf')
+        expect(result.prefixes.foaf).toBe('http://xmlns.com/foaf/0.1/')
+    })
+
+    it('returns error for invalid Turtle', async () => {
+        const result = await parseTurtle(INVALID_TURTLE)
+        expect(result.error).toBeDefined()
+        expect(result.error).toBeTruthy()
+    })
+
+    it('handles empty string without error', async () => {
+        const result = await parseTurtle('')
+        expect(result.error).toBeUndefined()
+        expect(result.store.size).toBe(0)
+    })
+
+    it('handles only prefix declarations', async () => {
+        const result = await parseTurtle('@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .')
+        expect(result.error).toBeUndefined()
+        expect(result.store.size).toBe(0)
+        expect(result.prefixes).toHaveProperty('rdf')
+    })
+})
+
+describe('parseNTriples', () => {
+    it('parses valid N-Triples', async () => {
+        const result = await parseNTriples(VALID_NTRIPLES)
+        expect(result.error).toBeUndefined()
+        expect(result.store.size).toBe(2)
+        // N-Triples has no prefixes
+        expect(Object.keys(result.prefixes)).toHaveLength(0)
+    })
+
+    it('returns error for invalid N-Triples', async () => {
+        const result = await parseNTriples('invalid data here')
+        expect(result.error).toBeDefined()
+    })
+})
+
+describe('parseJsonLd', () => {
+    it('parses valid JSON-LD', async () => {
+        const jsonld = JSON.stringify({
+            '@context': { 'name': 'http://xmlns.com/foaf/0.1/name' },
+            '@id': 'http://example.org/alice',
+            'name': 'Alice',
+        })
+        const result = await parseJsonLd(jsonld)
+        expect(result.error).toBeUndefined()
+        expect(result.store.size).toBeGreaterThan(0)
+    })
+
+    it('returns error for invalid JSON', async () => {
+        const result = await parseJsonLd('not json')
+        expect(result.error).toBeDefined()
+    })
+})
+
+describe('parseAuto', () => {
+    it('auto-detects Turtle format', async () => {
+        const result = await parseAuto(VALID_TURTLE)
+        expect(result.error).toBeUndefined()
+        expect(result.store.size).toBe(3)
+    })
+
+    it('auto-detects JSON-LD by leading {', async () => {
+        const jsonld = JSON.stringify({
+            '@id': 'http://example.org/x',
+            'http://xmlns.com/foaf/0.1/name': 'X',
+        })
+        const result = await parseAuto(jsonld)
+        expect(result.error).toBeUndefined()
+        expect(result.store.size).toBeGreaterThan(0)
+    })
+
+    it('uses hint for N-Triples', async () => {
+        const result = await parseAuto(VALID_NTRIPLES, 'n-triples')
+        expect(result.error).toBeUndefined()
+        expect(result.store.size).toBe(2)
+    })
+})

--- a/src/lib/rdf/__tests__/serializer.test.ts
+++ b/src/lib/rdf/__tests__/serializer.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest'
+import * as N3 from 'n3'
+import { serializeTurtle, serializeNTriples } from '../serializer'
+import { parseTurtle } from '../parser'
+
+const { namedNode, literal, quad } = N3.DataFactory
+
+function makeTestStore(): N3.Store {
+    const store = new N3.Store()
+    store.add(quad(
+        namedNode('http://example.org/alice'),
+        namedNode('http://xmlns.com/foaf/0.1/name'),
+        literal('Alice'),
+    ))
+    store.add(quad(
+        namedNode('http://example.org/alice'),
+        namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),
+        namedNode('http://xmlns.com/foaf/0.1/Person'),
+    ))
+    return store
+}
+
+describe('serializeTurtle', () => {
+    it('serializes store to Turtle with prefixes', async () => {
+        const store = makeTestStore()
+        const turtle = await serializeTurtle(store, { foaf: 'http://xmlns.com/foaf/0.1/' })
+        expect(turtle).toContain('foaf:name')
+        expect(turtle).toContain('"Alice"')
+    })
+
+    it('serializes store without prefixes', async () => {
+        const store = makeTestStore()
+        const turtle = await serializeTurtle(store)
+        expect(turtle).toBeTruthy()
+        expect(turtle).toContain('Alice')
+    })
+})
+
+describe('serializeNTriples', () => {
+    it('serializes store to N-Triples', async () => {
+        const store = makeTestStore()
+        const nt = await serializeNTriples(store)
+        expect(nt).toContain('<http://example.org/alice>')
+        expect(nt).toContain('<http://xmlns.com/foaf/0.1/name>')
+        expect(nt).toContain('"Alice"')
+        // N-Triples lines end with .
+        const lines = nt.trim().split('\n').filter((l) => l.trim())
+        expect(lines).toHaveLength(2)
+    })
+})
+
+describe('round-trip', () => {
+    it('parse → serialize → parse produces same triple count', async () => {
+        const original = `
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+<http://example.org/alice> a foaf:Person ;
+    foaf:name "Alice" ;
+    foaf:knows <http://example.org/bob> .
+
+<http://example.org/bob> a foaf:Person ;
+    foaf:name "Bob" .
+`
+        const parsed1 = await parseTurtle(original)
+        expect(parsed1.error).toBeUndefined()
+
+        const serialized = await serializeTurtle(parsed1.store, parsed1.prefixes)
+        const parsed2 = await parseTurtle(serialized)
+        expect(parsed2.error).toBeUndefined()
+
+        expect(parsed2.store.size).toBe(parsed1.store.size)
+    })
+})

--- a/src/lib/rdf/__tests__/store.test.ts
+++ b/src/lib/rdf/__tests__/store.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest'
+import * as N3 from 'n3'
+import {
+    storeToTriples,
+    getSubjects,
+    getTriplesForSubject,
+    getOne,
+    getAll,
+    resolveRdfList,
+    getLabel,
+} from '../store'
+
+const { namedNode, literal, quad, blankNode } = N3.DataFactory
+
+function makeTestStore(): N3.Store {
+    const store = new N3.Store()
+    store.add(quad(
+        namedNode('http://example.org/alice'),
+        namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),
+        namedNode('http://xmlns.com/foaf/0.1/Person'),
+    ))
+    store.add(quad(
+        namedNode('http://example.org/alice'),
+        namedNode('http://xmlns.com/foaf/0.1/name'),
+        literal('Alice'),
+    ))
+    store.add(quad(
+        namedNode('http://example.org/alice'),
+        namedNode('http://xmlns.com/foaf/0.1/knows'),
+        namedNode('http://example.org/bob'),
+    ))
+    store.add(quad(
+        namedNode('http://example.org/bob'),
+        namedNode('http://xmlns.com/foaf/0.1/name'),
+        literal('Bob'),
+    ))
+    return store
+}
+
+describe('storeToTriples', () => {
+    it('converts all quads to Triple objects', () => {
+        const triples = storeToTriples(makeTestStore())
+        expect(triples).toHaveLength(4)
+        const aliceName = triples.find((t) => t.object === 'Alice')
+        expect(aliceName).toBeDefined()
+        expect(aliceName!.objectType).toBe('literal')
+        expect(aliceName!.subject).toBe('http://example.org/alice')
+    })
+})
+
+describe('getSubjects', () => {
+    it('returns unique subjects', () => {
+        const subjects = getSubjects(makeTestStore())
+        expect(subjects).toContain('http://example.org/alice')
+        expect(subjects).toContain('http://example.org/bob')
+        expect(subjects).toHaveLength(2)
+    })
+})
+
+describe('getTriplesForSubject', () => {
+    it('returns all triples for a given subject', () => {
+        const triples = getTriplesForSubject(makeTestStore(), 'http://example.org/alice')
+        expect(triples).toHaveLength(3) // type, name, knows
+    })
+
+    it('returns empty array for unknown subject', () => {
+        const triples = getTriplesForSubject(makeTestStore(), 'http://example.org/unknown')
+        expect(triples).toHaveLength(0)
+    })
+})
+
+describe('getOne', () => {
+    it('returns first value of a predicate', () => {
+        const name = getOne(makeTestStore(), 'http://example.org/alice', 'http://xmlns.com/foaf/0.1/name')
+        expect(name).toBe('Alice')
+    })
+
+    it('returns undefined when predicate not found', () => {
+        const val = getOne(makeTestStore(), 'http://example.org/alice', 'http://example.org/nonexistent')
+        expect(val).toBeUndefined()
+    })
+})
+
+describe('getAll', () => {
+    it('returns all values of a predicate', () => {
+        const store = makeTestStore()
+        // Alice knows Bob; add Carol
+        store.add(quad(
+            namedNode('http://example.org/alice'),
+            namedNode('http://xmlns.com/foaf/0.1/knows'),
+            namedNode('http://example.org/carol'),
+        ))
+        const known = getAll(store, 'http://example.org/alice', 'http://xmlns.com/foaf/0.1/knows')
+        expect(known).toHaveLength(2)
+        expect(known).toContain('http://example.org/bob')
+        expect(known).toContain('http://example.org/carol')
+    })
+})
+
+describe('resolveRdfList', () => {
+    it('resolves an RDF list', () => {
+        const store = new N3.Store()
+        const RDF = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#'
+
+        // resolveRdfList uses getOne which uses namedNode(), so we need
+        // to use named nodes (IRIs) rather than blank nodes for the list nodes
+        const n1 = namedNode('http://example.org/list1')
+        const n2 = namedNode('http://example.org/list2')
+        store.add(quad(n1, namedNode(`${RDF}first`), literal('a')))
+        store.add(quad(n1, namedNode(`${RDF}rest`), n2))
+        store.add(quad(n2, namedNode(`${RDF}first`), literal('b')))
+        store.add(quad(n2, namedNode(`${RDF}rest`), namedNode(`${RDF}nil`)))
+
+        const items = resolveRdfList(store, 'http://example.org/list1')
+        expect(items).toEqual(['a', 'b'])
+    })
+})
+
+describe('getLabel', () => {
+    it('returns rdfs:label when available', () => {
+        const store = makeTestStore()
+        store.add(quad(
+            namedNode('http://example.org/alice'),
+            namedNode('http://www.w3.org/2000/01/rdf-schema#label'),
+            literal('Alice Wonder'),
+        ))
+        expect(getLabel(store, 'http://example.org/alice')).toBe('Alice Wonder')
+    })
+
+    it('falls back to shortened IRI when no label', () => {
+        const label = getLabel(makeTestStore(), 'http://example.org/alice')
+        // Should use shorten, which extracts 'alice' from the IRI
+        expect(label).toBe('alice')
+    })
+})

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,10 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
 import './index.css'
+import { initializeDomains } from './store/initDomains'
+
+// Register built-in domains and load default content
+initializeDomains()
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/src/store/__tests__/domainStore.test.ts
+++ b/src/store/__tests__/domainStore.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import * as N3 from 'n3'
+import { useDomainStore } from '../domainStore'
+import { useRdfStore } from '../rdfStore'
+import type { DomainInfo } from '../domainStore'
+
+const TEST_DOMAIN: DomainInfo = {
+    id: 'test-domain',
+    label: 'Test Domain',
+    templates: [
+        {
+            id: 'tmpl-1',
+            label: 'Test Template',
+            turtleContent: '@prefix ex: <http://example.org/> .\nex:test a ex:Thing .',
+        },
+        {
+            id: 'tmpl-2',
+            label: 'Another Template',
+            turtleContent: '@prefix ex: <http://example.org/> .\nex:other a ex:Widget .',
+        },
+    ],
+}
+
+beforeEach(() => {
+    useDomainStore.setState({
+        activeDomainId: 'free',
+        registeredDomains: new Map(),
+    })
+    useRdfStore.setState({
+        turtleText: '',
+        store: new N3.Store(),
+        prefixes: {},
+        parseError: null,
+        isParsing: false,
+    })
+})
+
+describe('domainStore', () => {
+    describe('registerDomain', () => {
+        it('registers a domain', () => {
+            useDomainStore.getState().registerDomain(TEST_DOMAIN)
+            const domains = useDomainStore.getState().registeredDomains
+            expect(domains.has('test-domain')).toBe(true)
+            expect(domains.get('test-domain')?.label).toBe('Test Domain')
+        })
+
+        it('registers multiple domains', () => {
+            useDomainStore.getState().registerDomain(TEST_DOMAIN)
+            useDomainStore.getState().registerDomain({
+                id: 'other',
+                label: 'Other',
+                templates: [],
+            })
+            expect(useDomainStore.getState().registeredDomains.size).toBe(2)
+        })
+
+        it('overwrites domain with same id', () => {
+            useDomainStore.getState().registerDomain(TEST_DOMAIN)
+            useDomainStore.getState().registerDomain({
+                ...TEST_DOMAIN,
+                label: 'Updated Label',
+            })
+            const domain = useDomainStore.getState().registeredDomains.get('test-domain')
+            expect(domain?.label).toBe('Updated Label')
+        })
+    })
+
+    describe('setActiveDomain', () => {
+        it('changes the active domain', () => {
+            useDomainStore.getState().setActiveDomain('samm')
+            expect(useDomainStore.getState().activeDomainId).toBe('samm')
+        })
+    })
+
+    describe('loadTemplate', () => {
+        it('loads template content into rdfStore', () => {
+            useDomainStore.getState().registerDomain(TEST_DOMAIN)
+            useDomainStore.getState().loadTemplate('test-domain', 'tmpl-1')
+
+            expect(useRdfStore.getState().turtleText).toContain('ex:test')
+            expect(useDomainStore.getState().activeDomainId).toBe('test-domain')
+        })
+
+        it('does nothing for unknown domain', () => {
+            useDomainStore.getState().loadTemplate('nonexistent', 'tmpl-1')
+            expect(useRdfStore.getState().turtleText).toBe('')
+        })
+
+        it('does nothing for unknown template', () => {
+            useDomainStore.getState().registerDomain(TEST_DOMAIN)
+            useDomainStore.getState().loadTemplate('test-domain', 'nonexistent')
+            expect(useRdfStore.getState().turtleText).toBe('')
+        })
+    })
+})

--- a/src/store/__tests__/rdfStore.test.ts
+++ b/src/store/__tests__/rdfStore.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import * as N3 from 'n3'
+import { useRdfStore } from '../rdfStore'
+
+// Reset store state before each test
+beforeEach(() => {
+    useRdfStore.setState({
+        turtleText: '',
+        store: new N3.Store(),
+        prefixes: {},
+        parseError: null,
+        isParsing: false,
+    })
+})
+
+describe('rdfStore', () => {
+    describe('setTurtleText', () => {
+        it('updates turtleText immediately', () => {
+            const { setTurtleText } = useRdfStore.getState()
+            setTurtleText('some turtle text')
+            expect(useRdfStore.getState().turtleText).toBe('some turtle text')
+        })
+
+        it('clears parseError on new text', () => {
+            useRdfStore.setState({ parseError: 'old error' })
+            const { setTurtleText } = useRdfStore.getState()
+            setTurtleText('new text')
+            expect(useRdfStore.getState().parseError).toBeNull()
+        })
+    })
+
+    describe('reparseNow', () => {
+        it('parses turtleText and populates store', async () => {
+            const turtle = `
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+<http://example.org/alice> foaf:name "Alice" .
+`
+            useRdfStore.setState({ turtleText: turtle })
+            await useRdfStore.getState().reparseNow()
+
+            const state = useRdfStore.getState()
+            expect(state.store.size).toBe(1)
+            expect(state.prefixes).toHaveProperty('foaf')
+            expect(state.parseError).toBeNull()
+            expect(state.isParsing).toBe(false)
+        })
+
+        it('sets parseError for invalid Turtle', async () => {
+            useRdfStore.setState({ turtleText: '<bad> <data "unterminated' })
+            await useRdfStore.getState().reparseNow()
+
+            const state = useRdfStore.getState()
+            expect(state.parseError).toBeTruthy()
+        })
+    })
+
+    describe('importFile', () => {
+        it('imports Turtle content', async () => {
+            const content = `
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+<http://example.org/x> rdf:type <http://example.org/Thing> .
+`
+            await useRdfStore.getState().importFile(content, 'turtle')
+
+            const state = useRdfStore.getState()
+            expect(state.store.size).toBe(1)
+            expect(state.turtleText).toBeTruthy()
+            expect(state.parseError).toBeNull()
+        })
+
+        it('imports N-Triples content', async () => {
+            const content = '<http://example.org/a> <http://example.org/b> <http://example.org/c> .\n'
+            await useRdfStore.getState().importFile(content, 'n-triples')
+
+            const state = useRdfStore.getState()
+            expect(state.store.size).toBe(1)
+        })
+
+        it('sets error for invalid import', async () => {
+            await useRdfStore.getState().importFile('invalid content', 'turtle')
+            const state = useRdfStore.getState()
+            expect(state.parseError).toBeTruthy()
+        })
+    })
+
+    describe('clearAll', () => {
+        it('resets all state', () => {
+            useRdfStore.setState({
+                turtleText: 'some text',
+                parseError: 'some error',
+            })
+            useRdfStore.getState().clearAll()
+
+            const state = useRdfStore.getState()
+            expect(state.turtleText).toBe('')
+            expect(state.store.size).toBe(0)
+            expect(state.parseError).toBeNull()
+            expect(Object.keys(state.prefixes)).toHaveLength(0)
+        })
+    })
+
+    describe('applyStoreChange', () => {
+        it('serializes store back to turtleText', async () => {
+            // Set up store with a triple
+            const store = new N3.Store()
+            store.add(N3.DataFactory.quad(
+                N3.DataFactory.namedNode('http://example.org/s'),
+                N3.DataFactory.namedNode('http://example.org/p'),
+                N3.DataFactory.literal('object'),
+            ))
+            useRdfStore.setState({ store, prefixes: {} })
+
+            await useRdfStore.getState().applyStoreChange()
+
+            const text = useRdfStore.getState().turtleText
+            expect(text).toContain('http://example.org/s')
+            expect(text).toContain('"object"')
+        })
+    })
+})

--- a/src/store/domainStore.ts
+++ b/src/store/domainStore.ts
@@ -1,0 +1,60 @@
+import { create } from 'zustand'
+import { useRdfStore } from './rdfStore'
+
+/**
+ * Lightweight domain template definition.
+ * Will be replaced by the full DomainPlugin interface in R-2.
+ */
+export interface DomainTemplate {
+    id: string
+    label: string
+    turtleContent: string
+}
+
+export interface DomainInfo {
+    id: string
+    label: string
+    templates: DomainTemplate[]
+}
+
+export interface DomainState {
+    /** Currently active domain ID. 'free' is the default. */
+    activeDomainId: string
+    /** Registered domain definitions, keyed by domain ID. */
+    registeredDomains: Map<string, DomainInfo>
+
+    registerDomain: (domain: DomainInfo) => void
+    setActiveDomain: (id: string) => void
+    loadTemplate: (domainId: string, templateId: string) => void
+}
+
+export const useDomainStore = create<DomainState>((set, get) => ({
+    activeDomainId: 'free',
+    registeredDomains: new Map(),
+
+    registerDomain: (domain) => {
+        set((state) => {
+            const updated = new Map(state.registeredDomains)
+            updated.set(domain.id, domain)
+            return { registeredDomains: updated }
+        })
+    },
+
+    setActiveDomain: (id) => {
+        set({ activeDomainId: id })
+    },
+
+    loadTemplate: (domainId, templateId) => {
+        const domain = get().registeredDomains.get(domainId)
+        if (!domain) return
+        const template = domain.templates.find((t) => t.id === templateId)
+        if (!template) return
+
+        // Update the RDF store with the template content
+        const rdfStore = useRdfStore.getState()
+        rdfStore.setTurtleText(template.turtleContent)
+        rdfStore.reparseNow()
+
+        set({ activeDomainId: domainId })
+    },
+}))

--- a/src/store/initDomains.ts
+++ b/src/store/initDomains.ts
@@ -1,0 +1,43 @@
+/**
+ * Register built-in domains (Free/FOAF and SAMM) into the domain store.
+ * Called once at app startup from main.tsx.
+ */
+import { useDomainStore } from './domainStore'
+import { useRdfStore } from './rdfStore'
+import { FOAF_EXAMPLE, SAMM_EXAMPLE } from '../lib/samm/templates'
+import type { DomainInfo } from './domainStore'
+
+const FREE_DOMAIN: DomainInfo = {
+    id: 'free',
+    label: 'Free',
+    templates: [
+        {
+            id: 'foaf',
+            label: 'FOAF Graph',
+            turtleContent: FOAF_EXAMPLE,
+        },
+    ],
+}
+
+const SAMM_DOMAIN: DomainInfo = {
+    id: 'samm',
+    label: 'SAMM',
+    templates: [
+        {
+            id: 'samm-basic',
+            label: 'SAMM Aspect',
+            turtleContent: SAMM_EXAMPLE,
+        },
+    ],
+}
+
+export function initializeDomains() {
+    const domainStore = useDomainStore.getState()
+    domainStore.registerDomain(FREE_DOMAIN)
+    domainStore.registerDomain(SAMM_DOMAIN)
+
+    // Load default content and trigger initial parse
+    const rdfStore = useRdfStore.getState()
+    rdfStore.setTurtleText(FOAF_EXAMPLE)
+    rdfStore.reparseNow()
+}

--- a/src/store/rdfStore.ts
+++ b/src/store/rdfStore.ts
@@ -1,0 +1,123 @@
+import { create } from 'zustand'
+import * as N3 from 'n3'
+import { parseTurtle, parseNTriples, parseJsonLd } from '../lib/rdf/parser'
+import { serializeTurtle, serializeNTriples, downloadText } from '../lib/rdf/serializer'
+import type { RdfFormat } from '../types/rdf'
+
+export interface RdfState {
+    // RDF core data
+    turtleText: string
+    store: N3.Store
+    prefixes: Record<string, string>
+    parseError: string | null
+    isParsing: boolean
+
+    // Actions
+    setTurtleText: (text: string) => void
+    reparseNow: () => Promise<void>
+    importFile: (content: string, format: RdfFormat) => Promise<void>
+    exportAs: (format: RdfFormat) => Promise<void>
+    clearAll: () => void
+
+    /**
+     * Re-serialize the current N3.Store back to Turtle and update turtleText.
+     * Used by storeWriter after direct Store mutations (graph/table editing).
+     */
+    applyStoreChange: () => Promise<void>
+}
+
+// Debounce timer for auto-parse
+let parseTimer: ReturnType<typeof setTimeout> | null = null
+
+async function applyParseResult(
+    text: string,
+    set: (partial: Partial<RdfState>) => void
+): Promise<void> {
+    set({ isParsing: true })
+    const result = await parseTurtle(text)
+    set({
+        store: result.store,
+        prefixes: result.prefixes,
+        parseError: result.error ?? null,
+        isParsing: false,
+    })
+}
+
+export const useRdfStore = create<RdfState>((set, get) => ({
+    turtleText: '',
+    store: new N3.Store(),
+    prefixes: {},
+    parseError: null,
+    isParsing: false,
+
+    setTurtleText: (text) => {
+        set({ turtleText: text, parseError: null })
+        // Debounce parsing: 400ms after last keystroke
+        if (parseTimer) clearTimeout(parseTimer)
+        parseTimer = setTimeout(() => applyParseResult(text, set), 400)
+    },
+
+    reparseNow: async () => {
+        if (parseTimer) { clearTimeout(parseTimer); parseTimer = null }
+        await applyParseResult(get().turtleText, set)
+    },
+
+    importFile: async (content, format) => {
+        let parseResult
+        if (format === 'turtle') {
+            parseResult = await parseTurtle(content)
+        } else if (format === 'n-triples' || format === 'n-quads') {
+            parseResult = await parseNTriples(content, format === 'n-quads' ? 'N-Quads' : 'N-Triples')
+        } else if (format === 'jsonld') {
+            parseResult = await parseJsonLd(content)
+        } else {
+            return
+        }
+
+        if (parseResult.error) {
+            set({ parseError: parseResult.error })
+            return
+        }
+
+        // Convert to Turtle for the editor
+        const turtle = await serializeTurtle(parseResult.store, parseResult.prefixes)
+        set({
+            turtleText: turtle,
+            store: parseResult.store,
+            prefixes: parseResult.prefixes,
+            parseError: null,
+        })
+    },
+
+    exportAs: async (format) => {
+        const { store, prefixes, turtleText } = get()
+        if (format === 'turtle') {
+            downloadText(turtleText, 'model.ttl', 'text/turtle')
+        } else if (format === 'n-triples') {
+            const nt = await serializeNTriples(store)
+            downloadText(nt, 'model.nt', 'application/n-triples')
+        } else if (format === 'jsonld') {
+            // Convert via N-Triples → jsonld
+            try {
+                const nt = await serializeNTriples(store)
+                const jsonld = await import('jsonld')
+                const doc = await (jsonld.default as typeof import('jsonld')).fromRDF(nt, {
+                    format: 'application/n-quads',
+                })
+                downloadText(JSON.stringify(doc, null, 2), 'model.jsonld', 'application/ld+json')
+            } catch (err) {
+                console.error('JSON-LD export failed', err)
+            }
+        }
+    },
+
+    clearAll: () => {
+        set({ turtleText: '', store: new N3.Store(), prefixes: {}, parseError: null })
+    },
+
+    applyStoreChange: async () => {
+        const { store, prefixes } = get()
+        const turtle = await serializeTurtle(store, prefixes)
+        set({ turtleText: turtle })
+    },
+}))

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -1,0 +1,19 @@
+import { create } from 'zustand'
+
+export type ActiveView = 'editor' | 'graph' | 'table' | 'split'
+
+export interface UiState {
+    activeView: ActiveView
+    selectedNode: string | null
+
+    setActiveView: (view: ActiveView) => void
+    setSelectedNode: (iri: string | null) => void
+}
+
+export const useUiStore = create<UiState>((set) => ({
+    activeView: 'split',
+    selectedNode: null,
+
+    setActiveView: (view) => set({ activeView: view }),
+    setSelectedNode: (iri) => set({ selectedNode: iri }),
+}))

--- a/src/store/validationStore.ts
+++ b/src/store/validationStore.ts
@@ -1,0 +1,30 @@
+import { create } from 'zustand'
+
+/**
+ * Validation store — skeleton for future SHACL validation (B-3).
+ */
+
+export interface ValidationResult {
+    path: string
+    message: string
+    severity: 'error' | 'warning' | 'info'
+    focusNode?: string
+    line?: number
+    column?: number
+}
+
+export interface ValidationState {
+    results: ValidationResult[]
+    isValidating: boolean
+
+    setResults: (results: ValidationResult[]) => void
+    clearResults: () => void
+}
+
+export const useValidationStore = create<ValidationState>((set) => ({
+    results: [],
+    isValidating: false,
+
+    setResults: (results) => set({ results, isValidating: false }),
+    clearResults: () => set({ results: [], isValidating: false }),
+}))

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom'

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,4 @@
+/// <reference types="vitest" />
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
@@ -6,4 +7,11 @@ export default defineConfig({
   optimizeDeps: {
     include: ['n3', 'cytoscape', 'cytoscape-cose-bilkent'],
   },
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.test.{ts,tsx}'],
+  },
 })
+
+


### PR DESCRIPTION
## 概要

Issue #2 ([R-1] Zustand ストアを Slices パターンで分割する) に対応するPRです。

## 変更内容

### R-1: Zustand ストア分割
- `appStore.ts` を4つの専用ストアに分割:
  - **`rdfStore.ts`**: RDFデータ状態・パース・Import/Export・`applyStoreChange()`
  - **`uiStore.ts`**: ActiveView, selectedNode
  - **`domainStore.ts`**: 動的ドメイン登録・テンプレートロード
  - **`validationStore.ts`**: バリデーション結果スケルトン（将来拡張用）
- **`initDomains.ts`**: 起動時にFree/SAMMドメインを登録
- 全7コンポーネントの import を新ストアに移行
- `AppLayout`: モード切替・テンプレートメニューを**動的生成**に変更

### テスト基盤導入
- **Vitest** を導入
- **6テストファイル / 50テスト** — ALL PASS ✅
  | ファイル | テスト数 | 対象 |
  |---|---|---|
  | parser.test.ts | 11 | Turtle/N-Triples/JSON-LD パース |
  | serializer.test.ts | 4 | シリアライズ + ラウンドトリップ |
  | namespaces.test.ts | 9 | IRI短縮 / localName |
  | store.test.ts | 10 | クエリユーティリティ |
  | rdfStore.test.ts | 9 | Zustand アクション |
  | domainStore.test.ts | 7 | ドメイン登録・テンプレート |

## 検証
- [x] `tsc --noEmit` — エラーなし
- [x] `npm run build` — 成功
- [x] `npx vitest run` — 50/50 PASS
- [x] ブラウザ動作確認 — FOAF/SAMMテンプレート、モード切替、グラフ描画、ステータスバー全て正常

## 注意事項
> `appStore.ts` はまだ削除していません。Claude Code の R-3 (Editor Extension Points) が完了し、`appStore` への参照がないことを確認後に削除します。

Closes #2