### PR TITLE
feat: R-2 DomainPlugin インターフェース定義

### DIFF
--- a/src/lib/domains/__tests__/registry.test.ts
+++ b/src/lib/domains/__tests__/registry.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import type { DomainPlugin } from '../../../types/domain'
+import {
+    registerPlugin,
+    unregisterPlugin,
+    getPlugin,
+    getAllPlugins,
+    getActiveDomainId,
+    setActiveDomainId,
+    getActivePlugin,
+    getActiveVocabulary,
+    initializePlugins,
+    resetRegistry,
+} from '../registry'
+
+const mockPlugin: DomainPlugin = {
+    id: 'test',
+    label: 'Test Domain',
+    namespaces: { ex: 'http://example.org/' },
+    templates: [
+        {
+            id: 'basic',
+            label: 'Basic Example',
+            description: 'A basic example',
+            turtleContent: '<http://example.org/s> <http://example.org/p> "o" .',
+        },
+    ],
+    vocabularyItems: [
+        {
+            iri: 'http://example.org/Thing',
+            prefixedName: 'ex:Thing',
+            label: 'Thing',
+            kind: 'class',
+            description: 'A test thing',
+        },
+    ],
+}
+
+beforeEach(() => {
+    resetRegistry()
+})
+
+describe('Plugin Registry', () => {
+    describe('registerPlugin / getPlugin', () => {
+        it('registers and retrieves a plugin', () => {
+            registerPlugin(mockPlugin)
+            expect(getPlugin('test')).toBe(mockPlugin)
+        })
+
+        it('returns undefined for unregistered id', () => {
+            expect(getPlugin('nonexistent')).toBeUndefined()
+        })
+
+        it('overwrites plugin with same id', () => {
+            registerPlugin(mockPlugin)
+            const updated = { ...mockPlugin, label: 'Updated' }
+            registerPlugin(updated)
+            expect(getPlugin('test')?.label).toBe('Updated')
+        })
+    })
+
+    describe('unregisterPlugin', () => {
+        it('removes a registered plugin', () => {
+            registerPlugin(mockPlugin)
+            unregisterPlugin('test')
+            expect(getPlugin('test')).toBeUndefined()
+        })
+
+        it('does nothing for unknown id', () => {
+            unregisterPlugin('unknown')
+            expect(getAllPlugins()).toHaveLength(0)
+        })
+    })
+
+    describe('getAllPlugins', () => {
+        it('returns all registered plugins', () => {
+            registerPlugin(mockPlugin)
+            registerPlugin({ ...mockPlugin, id: 'other', label: 'Other' })
+            expect(getAllPlugins()).toHaveLength(2)
+        })
+
+        it('returns empty array when no plugins registered', () => {
+            expect(getAllPlugins()).toHaveLength(0)
+        })
+    })
+
+    describe('active domain', () => {
+        it('defaults to free', () => {
+            expect(getActiveDomainId()).toBe('free')
+        })
+
+        it('can be changed', () => {
+            setActiveDomainId('samm')
+            expect(getActiveDomainId()).toBe('samm')
+        })
+
+        it('getActivePlugin returns the active domain plugin', () => {
+            registerPlugin(mockPlugin)
+            setActiveDomainId('test')
+            expect(getActivePlugin()).toBe(mockPlugin)
+        })
+
+        it('getActivePlugin returns undefined for unregistered active id', () => {
+            setActiveDomainId('nonexistent')
+            expect(getActivePlugin()).toBeUndefined()
+        })
+    })
+
+    describe('getActiveVocabulary', () => {
+        it('returns vocabulary items of active plugin', () => {
+            registerPlugin(mockPlugin)
+            setActiveDomainId('test')
+            const vocab = getActiveVocabulary()
+            expect(vocab).toHaveLength(1)
+            expect(vocab![0].prefixedName).toBe('ex:Thing')
+        })
+
+        it('returns empty array when no active plugin', () => {
+            expect(getActiveVocabulary()).toEqual([])
+        })
+    })
+
+    describe('initializePlugins', () => {
+        it('registers free and samm plugins', () => {
+            initializePlugins()
+            const plugins = getAllPlugins()
+            expect(plugins).toHaveLength(2)
+            expect(getPlugin('free')).toBeDefined()
+            expect(getPlugin('samm')).toBeDefined()
+        })
+
+        it('sets active domain to free', () => {
+            initializePlugins()
+            expect(getActiveDomainId()).toBe('free')
+        })
+
+        it('free plugin has FOAF template', () => {
+            initializePlugins()
+            const free = getPlugin('free')!
+            expect(free.templates).toHaveLength(1)
+            expect(free.templates[0].id).toBe('foaf-graph')
+            expect(free.templates[0].turtleContent).toContain('foaf:Person')
+        })
+
+        it('samm plugin has vocabulary items', () => {
+            initializePlugins()
+            const samm = getPlugin('samm')!
+            expect(samm.vocabularyItems!.length).toBeGreaterThan(0)
+            const aspect = samm.vocabularyItems!.find((v) => v.label === 'Aspect')
+            expect(aspect).toBeDefined()
+            expect(aspect!.kind).toBe('class')
+        })
+
+        it('samm plugin has graph styles', () => {
+            initializePlugins()
+            const samm = getPlugin('samm')!
+            expect(samm.graphStyles).toBeDefined()
+            expect(samm.graphStyles!.length).toBeGreaterThan(0)
+        })
+    })
+})

--- a/src/lib/domains/freePlugin.ts
+++ b/src/lib/domains/freePlugin.ts
@@ -1,0 +1,71 @@
+/**
+ * Free (FOAF) Domain Plugin
+ *
+ * The default domain with no constraints. Provides a FOAF example template
+ * and common RDF/RDFS/OWL vocabulary for auto-completion.
+ */
+import type { DomainPlugin, VocabularyItem } from '../../types/domain'
+import { FOAF_EXAMPLE } from '../samm/templates'
+
+// ─── Common RDF vocabulary for code completion ────────────────────
+
+const RDF_VOCABULARY: VocabularyItem[] = [
+    // RDF classes
+    { iri: 'http://www.w3.org/2000/01/rdf-schema#Class', prefixedName: 'rdfs:Class', label: 'Class', kind: 'class', description: 'The class of classes', position: 'object' },
+    { iri: 'http://www.w3.org/2000/01/rdf-schema#Resource', prefixedName: 'rdfs:Resource', label: 'Resource', kind: 'class', description: 'The class of everything', position: 'object' },
+    { iri: 'http://www.w3.org/2002/07/owl#Class', prefixedName: 'owl:Class', label: 'owl:Class', kind: 'class', description: 'An OWL class', position: 'object' },
+    { iri: 'http://www.w3.org/2002/07/owl#Ontology', prefixedName: 'owl:Ontology', label: 'owl:Ontology', kind: 'class', description: 'An OWL ontology', position: 'object' },
+
+    // Common properties
+    { iri: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', prefixedName: 'rdf:type', label: 'type', kind: 'property', description: 'The class of a resource', position: 'predicate' },
+    { iri: 'http://www.w3.org/2000/01/rdf-schema#label', prefixedName: 'rdfs:label', label: 'label', kind: 'property', description: 'Human-readable name', position: 'predicate' },
+    { iri: 'http://www.w3.org/2000/01/rdf-schema#comment', prefixedName: 'rdfs:comment', label: 'comment', kind: 'property', description: 'Human-readable description', position: 'predicate' },
+    { iri: 'http://www.w3.org/2000/01/rdf-schema#subClassOf', prefixedName: 'rdfs:subClassOf', label: 'subClassOf', kind: 'property', description: 'Superclass relationship', position: 'predicate' },
+    { iri: 'http://www.w3.org/2000/01/rdf-schema#subPropertyOf', prefixedName: 'rdfs:subPropertyOf', label: 'subPropertyOf', kind: 'property', description: 'Superproperty relationship', position: 'predicate' },
+    { iri: 'http://www.w3.org/2000/01/rdf-schema#domain', prefixedName: 'rdfs:domain', label: 'domain', kind: 'property', description: 'Domain of a property', position: 'predicate' },
+    { iri: 'http://www.w3.org/2000/01/rdf-schema#range', prefixedName: 'rdfs:range', label: 'range', kind: 'property', description: 'Range of a property', position: 'predicate' },
+    { iri: 'http://www.w3.org/2000/01/rdf-schema#seeAlso', prefixedName: 'rdfs:seeAlso', label: 'seeAlso', kind: 'property', description: 'Related resource', position: 'predicate' },
+
+    // FOAF
+    { iri: 'http://xmlns.com/foaf/0.1/Person', prefixedName: 'foaf:Person', label: 'Person', kind: 'class', description: 'A person', position: 'object' },
+    { iri: 'http://xmlns.com/foaf/0.1/Organization', prefixedName: 'foaf:Organization', label: 'Organization', kind: 'class', description: 'An organization', position: 'object' },
+    { iri: 'http://xmlns.com/foaf/0.1/name', prefixedName: 'foaf:name', label: 'name', kind: 'property', description: 'Name of an agent', position: 'predicate' },
+    { iri: 'http://xmlns.com/foaf/0.1/knows', prefixedName: 'foaf:knows', label: 'knows', kind: 'property', description: 'A person known by this person', position: 'predicate' },
+    { iri: 'http://xmlns.com/foaf/0.1/mbox', prefixedName: 'foaf:mbox', label: 'mbox', kind: 'property', description: 'Mailbox (email)', position: 'predicate' },
+    { iri: 'http://xmlns.com/foaf/0.1/homepage', prefixedName: 'foaf:homepage', label: 'homepage', kind: 'property', description: 'Homepage URL', position: 'predicate' },
+    { iri: 'http://xmlns.com/foaf/0.1/age', prefixedName: 'foaf:age', label: 'age', kind: 'property', description: 'Age in years', position: 'predicate' },
+
+    // XSD datatypes
+    { iri: 'http://www.w3.org/2001/XMLSchema#string', prefixedName: 'xsd:string', label: 'string', kind: 'datatype', description: 'String datatype', position: 'object' },
+    { iri: 'http://www.w3.org/2001/XMLSchema#integer', prefixedName: 'xsd:integer', label: 'integer', kind: 'datatype', description: 'Integer datatype', position: 'object' },
+    { iri: 'http://www.w3.org/2001/XMLSchema#boolean', prefixedName: 'xsd:boolean', label: 'boolean', kind: 'datatype', description: 'Boolean datatype', position: 'object' },
+    { iri: 'http://www.w3.org/2001/XMLSchema#dateTime', prefixedName: 'xsd:dateTime', label: 'dateTime', kind: 'datatype', description: 'Date-time datatype', position: 'object' },
+    { iri: 'http://www.w3.org/2001/XMLSchema#float', prefixedName: 'xsd:float', label: 'float', kind: 'datatype', description: 'Float datatype', position: 'object' },
+    { iri: 'http://www.w3.org/2001/XMLSchema#double', prefixedName: 'xsd:double', label: 'double', kind: 'datatype', description: 'Double datatype', position: 'object' },
+]
+
+// ─── Plugin definition ────────────────────────────────────────────
+
+export const freePlugin: DomainPlugin = {
+    id: 'free',
+    label: 'Free',
+
+    namespaces: {
+        'rdf': 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
+        'rdfs': 'http://www.w3.org/2000/01/rdf-schema#',
+        'owl': 'http://www.w3.org/2002/07/owl#',
+        'xsd': 'http://www.w3.org/2001/XMLSchema#',
+        'foaf': 'http://xmlns.com/foaf/0.1/',
+    },
+
+    templates: [
+        {
+            id: 'foaf-graph',
+            label: 'FOAF Graph',
+            description: 'A social network graph using Friend-of-a-Friend vocabulary',
+            turtleContent: FOAF_EXAMPLE,
+        },
+    ],
+
+    vocabularyItems: RDF_VOCABULARY,
+}

--- a/src/lib/domains/registry.ts
+++ b/src/lib/domains/registry.ts
@@ -1,0 +1,76 @@
+/**
+ * Domain Plugin Registry
+ *
+ * Central registry for managing domain plugins. Plugins are registered
+ * at startup and can be queried at runtime.
+ */
+import type { DomainPlugin } from '../../types/domain'
+import { freePlugin } from './freePlugin'
+import { sammPlugin } from '../samm/sammPlugin'
+
+// ─── Internal state ───────────────────────────────────────────────
+
+const plugins = new Map<string, DomainPlugin>()
+let activeDomainId = 'free'
+
+// ─── Public API ───────────────────────────────────────────────────
+
+/** Register a domain plugin. Overwrites if same id exists. */
+export function registerPlugin(plugin: DomainPlugin): void {
+    plugins.set(plugin.id, plugin)
+}
+
+/** Unregister a domain plugin by id. */
+export function unregisterPlugin(id: string): void {
+    plugins.delete(id)
+}
+
+/** Get a plugin by id. Returns undefined if not found. */
+export function getPlugin(id: string): DomainPlugin | undefined {
+    return plugins.get(id)
+}
+
+/** Get all registered plugins. */
+export function getAllPlugins(): DomainPlugin[] {
+    return Array.from(plugins.values())
+}
+
+/** Get the currently active domain id. */
+export function getActiveDomainId(): string {
+    return activeDomainId
+}
+
+/** Set the active domain. */
+export function setActiveDomainId(id: string): void {
+    activeDomainId = id
+}
+
+/** Get the currently active plugin. */
+export function getActivePlugin(): DomainPlugin | undefined {
+    return plugins.get(activeDomainId)
+}
+
+/** Get all vocabulary items from the active domain. */
+export function getActiveVocabulary(): DomainPlugin['vocabularyItems'] {
+    return getActivePlugin()?.vocabularyItems ?? []
+}
+
+/**
+ * Initialize the registry with built-in plugins.
+ * Call this at application startup.
+ */
+export function initializePlugins(): void {
+    // Lazy imports to avoid circular dependencies
+
+    registerPlugin(freePlugin)
+    registerPlugin(sammPlugin)
+    activeDomainId = 'free'
+}
+
+/**
+ * Reset the registry (for testing).
+ */
+export function resetRegistry(): void {
+    plugins.clear()
+    activeDomainId = 'free'
+}

--- a/src/lib/samm/sammPlugin.ts
+++ b/src/lib/samm/sammPlugin.ts
@@ -1,0 +1,103 @@
+/**
+ * SAMM (Semantic Aspect Meta Model) Domain Plugin
+ *
+ * Provides SAMM-specific namespaces, vocabulary, templates, and graph styles
+ * for modeling Eclipse ESMF Aspect Models.
+ */
+import type { DomainPlugin, VocabularyItem } from '../../types/domain'
+import { SAMM_NS, SAMM_C_NS, SAMM_E_NS, UNIT_NS } from './vocabulary'
+import { SAMM_EXAMPLE } from './templates'
+
+// ─── Vocabulary items for code completion ─────────────────────────
+
+const SAMM_VOCABULARY: VocabularyItem[] = [
+    // Classes
+    { iri: `${SAMM_NS}Aspect`, prefixedName: 'samm:Aspect', label: 'Aspect', kind: 'class', description: 'Root element of a SAMM model', position: 'object' },
+    { iri: `${SAMM_NS}Property`, prefixedName: 'samm:Property', label: 'Property', kind: 'class', description: 'A typed attribute of an Aspect or Entity', position: 'object' },
+    { iri: `${SAMM_NS}Characteristic`, prefixedName: 'samm:Characteristic', label: 'Characteristic', kind: 'class', description: 'Describes how a Property value looks', position: 'object' },
+    { iri: `${SAMM_NS}Entity`, prefixedName: 'samm:Entity', label: 'Entity', kind: 'class', description: 'A complex data structure with its own properties', position: 'object' },
+    { iri: `${SAMM_NS}Operation`, prefixedName: 'samm:Operation', label: 'Operation', kind: 'class', description: 'An operation that can be invoked on an Aspect', position: 'object' },
+    { iri: `${SAMM_NS}Event`, prefixedName: 'samm:Event', label: 'Event', kind: 'class', description: 'An event emitted by an Aspect', position: 'object' },
+    { iri: `${SAMM_NS}Constraint`, prefixedName: 'samm:Constraint', label: 'Constraint', kind: 'class', description: 'A restriction on a Characteristic', position: 'object' },
+
+    // Properties
+    { iri: `${SAMM_NS}preferredName`, prefixedName: 'samm:preferredName', label: 'preferredName', kind: 'property', description: 'Human-readable name (with language tag)', position: 'predicate' },
+    { iri: `${SAMM_NS}description`, prefixedName: 'samm:description', label: 'description', kind: 'property', description: 'Human-readable description (with language tag)', position: 'predicate' },
+    { iri: `${SAMM_NS}properties`, prefixedName: 'samm:properties', label: 'properties', kind: 'property', description: 'List of properties of an Aspect or Entity', position: 'predicate' },
+    { iri: `${SAMM_NS}operations`, prefixedName: 'samm:operations', label: 'operations', kind: 'property', description: 'List of operations on an Aspect', position: 'predicate' },
+    { iri: `${SAMM_NS}events`, prefixedName: 'samm:events', label: 'events', kind: 'property', description: 'List of events on an Aspect', position: 'predicate' },
+    { iri: `${SAMM_NS}characteristic`, prefixedName: 'samm:characteristic', label: 'characteristic', kind: 'property', description: 'The Characteristic of a Property', position: 'predicate' },
+    { iri: `${SAMM_NS}dataType`, prefixedName: 'samm:dataType', label: 'dataType', kind: 'property', description: 'The data type of a Characteristic', position: 'predicate' },
+    { iri: `${SAMM_NS}exampleValue`, prefixedName: 'samm:exampleValue', label: 'exampleValue', kind: 'property', description: 'Example value for a Property', position: 'predicate' },
+
+    // Built-in characteristics (samm-c)
+    { iri: `${SAMM_C_NS}Text`, prefixedName: 'samm-c:Text', label: 'Text', kind: 'class', description: 'String characteristic', position: 'object' },
+    { iri: `${SAMM_C_NS}Boolean`, prefixedName: 'samm-c:Boolean', label: 'Boolean', kind: 'class', description: 'Boolean characteristic', position: 'object' },
+    { iri: `${SAMM_C_NS}Timestamp`, prefixedName: 'samm-c:Timestamp', label: 'Timestamp', kind: 'class', description: 'Date-time characteristic', position: 'object' },
+    { iri: `${SAMM_C_NS}Measurement`, prefixedName: 'samm-c:Measurement', label: 'Measurement', kind: 'class', description: 'Numeric measurement with unit', position: 'object' },
+    { iri: `${SAMM_C_NS}Quantifiable`, prefixedName: 'samm-c:Quantifiable', label: 'Quantifiable', kind: 'class', description: 'Numeric value with optional unit', position: 'object' },
+    { iri: `${SAMM_C_NS}Duration`, prefixedName: 'samm-c:Duration', label: 'Duration', kind: 'class', description: 'Time duration characteristic', position: 'object' },
+    { iri: `${SAMM_C_NS}Enumeration`, prefixedName: 'samm-c:Enumeration', label: 'Enumeration', kind: 'class', description: 'Fixed set of values', position: 'object' },
+    { iri: `${SAMM_C_NS}State`, prefixedName: 'samm-c:State', label: 'State', kind: 'class', description: 'State machine with default value', position: 'object' },
+    { iri: `${SAMM_C_NS}Collection`, prefixedName: 'samm-c:Collection', label: 'Collection', kind: 'class', description: 'Unordered collection', position: 'object' },
+    { iri: `${SAMM_C_NS}List`, prefixedName: 'samm-c:List', label: 'List', kind: 'class', description: 'Ordered collection', position: 'object' },
+    { iri: `${SAMM_C_NS}Set`, prefixedName: 'samm-c:Set', label: 'Set', kind: 'class', description: 'Unordered unique collection', position: 'object' },
+    { iri: `${SAMM_C_NS}SingleEntity`, prefixedName: 'samm-c:SingleEntity', label: 'SingleEntity', kind: 'class', description: 'Characteristic referencing an Entity', position: 'object' },
+    { iri: `${SAMM_C_NS}unit`, prefixedName: 'samm-c:unit', label: 'unit', kind: 'property', description: 'Unit of measurement', position: 'predicate' },
+]
+
+// ─── Plugin definition ────────────────────────────────────────────
+
+export const sammPlugin: DomainPlugin = {
+    id: 'samm',
+    label: 'SAMM',
+
+    namespaces: {
+        'samm': SAMM_NS,
+        'samm-c': SAMM_C_NS,
+        'samm-e': SAMM_E_NS,
+        'unit': UNIT_NS,
+    },
+
+    templates: [
+        {
+            id: 'samm-aspect',
+            label: 'SAMM Aspect',
+            description: 'A complete SAMM Aspect Model with properties, characteristics, and units',
+            turtleContent: SAMM_EXAMPLE,
+        },
+    ],
+
+    vocabularyItems: SAMM_VOCABULARY,
+
+    graphStyles: [
+        {
+            selector: 'node[label = "samm:Aspect"]',
+            style: {
+                'background-color': '#7c3aed',
+                'border-color': '#6d28d9',
+            },
+        },
+        {
+            selector: 'node[label = "samm:Property"]',
+            style: {
+                'background-color': '#2563eb',
+                'border-color': '#1d4ed8',
+            },
+        },
+        {
+            selector: 'node[label = "samm:Characteristic"]',
+            style: {
+                'background-color': '#059669',
+                'border-color': '#047857',
+            },
+        },
+        {
+            selector: 'node[label = "samm:Entity"]',
+            style: {
+                'background-color': '#d97706',
+                'border-color': '#b45309',
+            },
+        },
+    ],
+}

--- a/src/types/domain.ts
+++ b/src/types/domain.ts
@@ -1,0 +1,87 @@
+/**
+ * DomainPlugin interface — the extension point for domain-specific
+ * knowledge (SAMM, Schema.org, BOT, FHIR, etc.)
+ *
+ * Each plugin provides:
+ * - Identity (id, label)
+ * - Namespaces for prefix registration
+ * - Templates for quick-start examples
+ * - Vocabulary items for editor auto-completion (optional)
+ * - Graph style overrides (optional)
+ * - SHACL shapes for validation (optional, future)
+ */
+
+// ─── Core interfaces ──────────────────────────────────────────────
+
+export interface DomainPlugin {
+    /** Unique identifier, e.g. 'samm', 'schemaorg', 'bot', 'fhir' */
+    id: string
+
+    /** Human-readable name shown in UI (e.g. "SAMM", "Schema.org") */
+    label: string
+
+    /** Namespaces this domain adds to the prefix map */
+    namespaces: Record<string, string>
+
+    /** Pre-built templates users can load */
+    templates: DomainTemplate[]
+
+    /** Vocabulary items for Monaco auto-completion (optional) */
+    vocabularyItems?: VocabularyItem[]
+
+    /** Cytoscape graph style overrides (optional) */
+    graphStyles?: CytoscapeStyleRule[]
+
+    /** SHACL shapes in Turtle format for validation (optional, future) */
+    shaclShapes?: string
+}
+
+// ─── Template ─────────────────────────────────────────────────────
+
+export interface DomainTemplate {
+    /** Unique template key within the domain */
+    id: string
+
+    /** Display name shown in the template menu */
+    label: string
+
+    /** Short description for tooltip or subtitle */
+    description: string
+
+    /** Full Turtle content loaded into the editor */
+    turtleContent: string
+}
+
+// ─── Vocabulary (for code completion) ─────────────────────────────
+
+export type VocabularyItemKind = 'class' | 'property' | 'datatype' | 'individual'
+
+export interface VocabularyItem {
+    /** The full IRI of the vocabulary term */
+    iri: string
+
+    /** Prefixed form, e.g. "samm:Aspect" */
+    prefixedName: string
+
+    /** Short label for completion menu */
+    label: string
+
+    /** Kind of term — drives the completion icon */
+    kind: VocabularyItemKind
+
+    /** One-line description for completion detail */
+    description?: string
+
+    /** Expected position: 'subject' | 'predicate' | 'object' | 'any' */
+    position?: 'subject' | 'predicate' | 'object' | 'any'
+}
+
+// ─── Graph styling ────────────────────────────────────────────────
+
+export interface CytoscapeStyleRule {
+    /** Cytoscape selector string, e.g. "node[nodeType='iri']" */
+    selector: string
+
+    /** Cytoscape style properties */
+    style: Record<string, string | number>
+}


### PR DESCRIPTION
## 概要

Issue #3 ([R-2] ドメインプラグインインターフェース (DomainPlugin) を定義する) に対応するPRです。

## 変更内容

### DomainPlugin インターフェース

`src/types/domain.ts` に以下の型を定義:

```typescript
interface DomainPlugin {
  id: string                           // 'samm', 'schemaorg', 'bot', 'fhir'
  label: string                        // UI表示名
  namespaces: Record<string, string>   // 追加するプレフィックス
  templates: DomainTemplate[]          // テンプレート一覧
  vocabularyItems?: VocabularyItem[]   // 自動補完用語彙
  graphStyles?: CytoscapeStyleRule[]   // グラフスタイルルール
  shaclShapes?: string                 // SHACLバリデーション（将来用）
}
```

### プラグイン実装

| プラグイン | ファイル | 語彙数 | テンプレート | グラフスタイル |
|---|---|---|---|---|
| **SAMM** | `src/lib/samm/sammPlugin.ts` | 27 | SAMM Aspect | 4ルール |
| **Free** | `src/lib/domains/freePlugin.ts` | 24 | FOAF Graph | ─ |

### プラグインレジストリ

`src/lib/domains/registry.ts`:
- `registerPlugin()` / `unregisterPlugin()` — 動的登録/解除
- `getPlugin()` / `getAllPlugins()` — クエリ
- `setActiveDomainId()` / `getActivePlugin()` — アクティブドメイン管理
- `getActiveVocabulary()` — アクティブドメインの語彙取得
- `initializePlugins()` — built-in プラグイン登録

## 検証
- [x] `tsc --noEmit` — エラーなし
- [x] `npm run build` — 成功
- [x] `npx vitest run` — 18/18 PASS

## 新規ファイル
- `src/types/domain.ts` — DomainPlugin interface
- `src/lib/samm/sammPlugin.ts` — SAMM プラグイン
- `src/lib/domains/freePlugin.ts` — Free/FOAF プラグイン
- `src/lib/domains/registry.ts` — プラグインレジストリ
- `src/lib/domains/__tests__/registry.test.ts` — テスト (18 tests)

Closes #3