### PR TITLE
feat: R-4 双方向同期のための StoreWriter

### DIFF
--- a/src/lib/rdf/__tests__/storeWriter.test.ts
+++ b/src/lib/rdf/__tests__/storeWriter.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import * as N3 from 'n3'
+import type { Triple } from '../../../types/rdf'
+import {
+    addTriple,
+    removeTriple,
+    updateTriple,
+    addTriples,
+    removeTriples,
+    removeSubject,
+    tripleToQuad,
+} from '../storeWriter'
+
+const { namedNode, literal } = N3.DataFactory
+
+// ─── Fixtures ─────────────────────────────────────────────────────
+
+const tripleA: Triple = {
+    subject: 'http://example.org/alice',
+    predicate: 'http://xmlns.com/foaf/0.1/name',
+    object: 'Alice',
+    objectType: 'literal',
+}
+
+const tripleB: Triple = {
+    subject: 'http://example.org/alice',
+    predicate: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',
+    object: 'http://xmlns.com/foaf/0.1/Person',
+    objectType: 'iri',
+}
+
+const tripleC: Triple = {
+    subject: 'http://example.org/bob',
+    predicate: 'http://xmlns.com/foaf/0.1/name',
+    object: 'Bob',
+    objectType: 'literal',
+}
+
+const tripleLang: Triple = {
+    subject: 'http://example.org/alice',
+    predicate: 'http://xmlns.com/foaf/0.1/name',
+    object: 'アリス',
+    objectType: 'literal',
+    language: 'ja',
+}
+
+const tripleTyped: Triple = {
+    subject: 'http://example.org/alice',
+    predicate: 'http://xmlns.com/foaf/0.1/age',
+    object: '30',
+    objectType: 'literal',
+    datatype: 'http://www.w3.org/2001/XMLSchema#integer',
+}
+
+const tripleBlank: Triple = {
+    subject: '_:b0',
+    predicate: 'http://xmlns.com/foaf/0.1/name',
+    object: 'Anon',
+    objectType: 'literal',
+}
+
+let store: N3.Store
+
+beforeEach(() => {
+    store = new N3.Store()
+})
+
+// ─── tripleToQuad ─────────────────────────────────────────────────
+
+describe('tripleToQuad', () => {
+    it('converts IRI object', () => {
+        const q = tripleToQuad(tripleB)
+        expect(q.subject.value).toBe('http://example.org/alice')
+        expect(q.predicate.value).toBe('http://www.w3.org/1999/02/22-rdf-syntax-ns#type')
+        expect(q.object.value).toBe('http://xmlns.com/foaf/0.1/Person')
+        expect(q.object.termType).toBe('NamedNode')
+    })
+
+    it('converts literal object', () => {
+        const q = tripleToQuad(tripleA)
+        expect(q.object.termType).toBe('Literal')
+        expect(q.object.value).toBe('Alice')
+    })
+
+    it('converts literal with language tag', () => {
+        const q = tripleToQuad(tripleLang)
+        expect(q.object.termType).toBe('Literal')
+        expect((q.object as N3.Literal).language).toBe('ja')
+    })
+
+    it('converts literal with datatype', () => {
+        const q = tripleToQuad(tripleTyped)
+        expect(q.object.termType).toBe('Literal')
+        expect((q.object as N3.Literal).datatype.value).toBe('http://www.w3.org/2001/XMLSchema#integer')
+    })
+
+    it('converts blank node subject', () => {
+        const q = tripleToQuad(tripleBlank)
+        expect(q.subject.termType).toBe('BlankNode')
+        expect(q.subject.value).toBe('b0')
+    })
+})
+
+// ─── addTriple ────────────────────────────────────────────────────
+
+describe('addTriple', () => {
+    it('adds a triple and returns true', () => {
+        const result = addTriple(store, tripleA)
+        expect(result).toBe(true)
+        expect(store.size).toBe(1)
+    })
+
+    it('returns false when triple already exists', () => {
+        addTriple(store, tripleA)
+        const result = addTriple(store, tripleA)
+        expect(result).toBe(false)
+        expect(store.size).toBe(1)
+    })
+
+    it('handles IRI, literal, and blank node objects', () => {
+        addTriple(store, tripleA) // literal
+        addTriple(store, tripleB) // IRI
+        addTriple(store, tripleBlank) // blank node subject
+        expect(store.size).toBe(3)
+    })
+})
+
+// ─── removeTriple ─────────────────────────────────────────────────
+
+describe('removeTriple', () => {
+    it('removes a triple and returns true', () => {
+        addTriple(store, tripleA)
+        const result = removeTriple(store, tripleA)
+        expect(result).toBe(true)
+        expect(store.size).toBe(0)
+    })
+
+    it('returns false when triple does not exist', () => {
+        const result = removeTriple(store, tripleA)
+        expect(result).toBe(false)
+    })
+})
+
+// ─── updateTriple ─────────────────────────────────────────────────
+
+describe('updateTriple', () => {
+    it('replaces old triple with new triple', () => {
+        addTriple(store, tripleA)
+        const updated: Triple = { ...tripleA, object: 'Bob' }
+        const result = updateTriple(store, tripleA, updated)
+        expect(result).toBe(true)
+        expect(store.size).toBe(1)
+
+        // Verify new value
+        const quads = store.getQuads(
+            namedNode('http://example.org/alice'),
+            namedNode('http://xmlns.com/foaf/0.1/name'),
+            null, null
+        )
+        expect(quads).toHaveLength(1)
+        expect(quads[0].object.value).toBe('Bob')
+    })
+
+    it('returns true even if old triple was not found (adds new)', () => {
+        const result = updateTriple(store, tripleA, tripleB)
+        expect(result).toBe(true)
+        expect(store.size).toBe(1)
+    })
+})
+
+// ─── addTriples / removeTriples ───────────────────────────────────
+
+describe('addTriples', () => {
+    it('adds multiple triples and returns count', () => {
+        const count = addTriples(store, [tripleA, tripleB, tripleC])
+        expect(count).toBe(3)
+        expect(store.size).toBe(3)
+    })
+
+    it('skips duplicates', () => {
+        addTriple(store, tripleA)
+        const count = addTriples(store, [tripleA, tripleB])
+        expect(count).toBe(1) // only tripleB was new
+        expect(store.size).toBe(2)
+    })
+})
+
+describe('removeTriples', () => {
+    it('removes multiple triples and returns count', () => {
+        addTriples(store, [tripleA, tripleB, tripleC])
+        const count = removeTriples(store, [tripleA, tripleC])
+        expect(count).toBe(2)
+        expect(store.size).toBe(1)
+    })
+})
+
+// ─── removeSubject ────────────────────────────────────────────────
+
+describe('removeSubject', () => {
+    it('removes all triples for a subject', () => {
+        addTriples(store, [tripleA, tripleB, tripleC]) // alice x2, bob x1
+        const count = removeSubject(store, 'http://example.org/alice')
+        expect(count).toBe(2)
+        expect(store.size).toBe(1) // only bob remains
+    })
+
+    it('returns 0 for unknown subject', () => {
+        const count = removeSubject(store, 'http://example.org/unknown')
+        expect(count).toBe(0)
+    })
+})
+
+// ─── Integration: round-trip via store ────────────────────────────
+
+describe('round-trip: add → query → verify', () => {
+    it('added triples are queryable via N3.Store', () => {
+        addTriple(store, tripleA)
+        addTriple(store, tripleB)
+
+        const aliceTriples = store.getQuads(
+            namedNode('http://example.org/alice'), null, null, null
+        )
+        expect(aliceTriples).toHaveLength(2)
+
+        const names = store.getQuads(
+            namedNode('http://example.org/alice'),
+            namedNode('http://xmlns.com/foaf/0.1/name'),
+            null, null
+        )
+        expect(names).toHaveLength(1)
+        expect(names[0].object.value).toBe('Alice')
+    })
+})

--- a/src/lib/rdf/storeWriter.ts
+++ b/src/lib/rdf/storeWriter.ts
@@ -1,0 +1,129 @@
+/**
+ * Store Writer – write operations for N3.Store
+ *
+ * Provides add / remove / update triple operations, enabling the
+ * reverse data flow:  Graph/Table UI → Store → serialize → Editor.
+ *
+ * All functions are pure (operate on a provided store) and return
+ * a boolean indicating whether a change was actually made.
+ */
+import * as N3 from 'n3'
+import type { Triple } from '../../types/rdf'
+
+const { namedNode, literal, blankNode, quad: makeQuad } = N3.DataFactory
+
+// ─── Helpers ──────────────────────────────────────────────────────
+
+/**
+ * Convert a Triple's object into an N3 Term based on objectType.
+ */
+function objectToTerm(
+    value: string,
+    objectType: Triple['objectType'],
+    datatype?: string,
+    language?: string
+): N3.NamedNode | N3.BlankNode | N3.Literal {
+    if (objectType === 'blank') {
+        return blankNode(value.startsWith('_:') ? value.slice(2) : value)
+    }
+    if (objectType === 'literal') {
+        if (language) {
+            return literal(value, language)
+        }
+        if (datatype && datatype !== 'http://www.w3.org/2001/XMLSchema#string') {
+            return literal(value, namedNode(datatype))
+        }
+        return literal(value)
+    }
+    return namedNode(value)
+}
+
+/**
+ * Convert a Triple into an N3.Quad.
+ */
+export function tripleToQuad(triple: Triple): N3.Quad {
+    const subject = triple.subject.startsWith('_:')
+        ? blankNode(triple.subject.slice(2))
+        : namedNode(triple.subject)
+    const predicate = namedNode(triple.predicate)
+    const object = objectToTerm(triple.object, triple.objectType, triple.datatype, triple.language)
+
+    return makeQuad(subject, predicate, object)
+}
+
+// ─── Write operations ─────────────────────────────────────────────
+
+/**
+ * Add a triple to the store.
+ * Returns true if the triple was newly added (not already present).
+ */
+export function addTriple(store: N3.Store, triple: Triple): boolean {
+    const q = tripleToQuad(triple)
+    const sizeBefore = store.size
+    store.add(q)
+    return store.size > sizeBefore
+}
+
+/**
+ * Remove a triple from the store.
+ * Returns true if a triple was actually removed.
+ */
+export function removeTriple(store: N3.Store, triple: Triple): boolean {
+    const q = tripleToQuad(triple)
+    const sizeBefore = store.size
+    store.delete(q)
+    return store.size < sizeBefore
+}
+
+/**
+ * Update a triple: remove the old one and add the new one.
+ * Returns true if the update resulted in a change.
+ */
+export function updateTriple(
+    store: N3.Store,
+    oldTriple: Triple,
+    newTriple: Triple
+): boolean {
+    const removed = removeTriple(store, oldTriple)
+    const added = addTriple(store, newTriple)
+    return removed || added
+}
+
+/**
+ * Add multiple triples at once.
+ * Returns the number of newly added triples.
+ */
+export function addTriples(store: N3.Store, triples: Triple[]): number {
+    let count = 0
+    for (const t of triples) {
+        if (addTriple(store, t)) count++
+    }
+    return count
+}
+
+/**
+ * Remove multiple triples at once.
+ * Returns the number of actually removed triples.
+ */
+export function removeTriples(store: N3.Store, triples: Triple[]): number {
+    let count = 0
+    for (const t of triples) {
+        if (removeTriple(store, t)) count++
+    }
+    return count
+}
+
+/**
+ * Remove all triples with the given subject.
+ * Returns the number of removed triples.
+ */
+export function removeSubject(store: N3.Store, subjectIri: string): number {
+    const subjectNode = namedNode(subjectIri)
+    const quads = store.getQuads(subjectNode, null, null, null)
+    let count = 0
+    for (const q of quads) {
+        store.delete(q)
+        count++
+    }
+    return count
+}

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -31,6 +31,7 @@ interface AppState {
   exportAs: (format: RdfFormat) => Promise<void>
   loadExample: (type: 'foaf' | 'samm') => void
   clearAll: () => void
+  applyStoreChange: () => Promise<void>
 }
 
 // Debounce timer for auto-parse
@@ -135,6 +136,12 @@ export const useAppStore = create<AppState>((set, get) => ({
 
   clearAll: () => {
     set({ turtleText: '', store: new N3.Store(), prefixes: {}, parseError: null })
+  },
+
+  applyStoreChange: async () => {
+    const { store, prefixes } = get()
+    const turtle = await serializeTurtle(store, prefixes)
+    set({ turtleText: turtle, parseError: null })
   },
 }))
 


### PR DESCRIPTION
## 概要

Issue #5 ([R-4] グラフ・テーブルからの双方向同期基盤を構築する) に対応するPRです。

## 変更内容

### 1. storeWriter 実装 (`storeWriter.ts`)
UIからの編集アクションを N3.Store に反映するための書き込み基盤。
- `addTriple()` / `removeTriple()` / `updateTriple()`
- バッチ処理用 `addTriples()` / `removeTriples()`
- `removeSubject()`
すべての関数は副作用として Store を更新し、「変更があったか」を boolean (または処理件数) で返します。

### 2. 双方向同期フローの確立 (`appStore.ts`)
新アクション `applyStoreChange()` を追加。
- Graph/Tableでの編集 -> `storeWriter` で store 更新 -> `applyStoreChange()` 呼び出し -> Store を Turtle に再シリアライズ -> エディタ更新
という逆方向のデータフローがこれで完成しました。

## 検証
- [x] `tsc --noEmit` — エラーなし
- [x] `npm run build` — 成功
- [x] `npx vitest run` — storeWriterの18テストすべてPASS (Round-trip含む)

Closes #5