### PR TITLE
feat: [A-3] Cytoscape のスタイリング・アイコン強化

### DIFF
--- a/src/components/graph/GraphLegend.tsx
+++ b/src/components/graph/GraphLegend.tsx
@@ -1,0 +1,64 @@
+import { useState } from 'react'
+import { TYPE_COLORS } from './graphUtils'
+
+/** Base node type colors (always shown) */
+const BASE_TYPES = [
+  { label: 'IRI Node', color: '#89b4fa', bg: '#1e1e2e', shape: 'ellipse' as const },
+  { label: 'Blank Node', color: '#6c7086', bg: '#1e1e2e', shape: 'ellipse' as const },
+  { label: 'Literal', color: '#f9e2af', bg: '#313244', shape: 'rectangle' as const },
+]
+
+export default function GraphLegend() {
+  const [isOpen, setIsOpen] = useState(false)
+
+  return (
+    <div className="absolute bottom-3 left-3 z-10">
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="px-2 py-1 rounded text-xs bg-surface-raised hover:bg-surface text-text-primary border border-surface-raised"
+        title="Toggle legend"
+      >
+        {isOpen ? '◀ Legend' : '▶ Legend'}
+      </button>
+
+      {isOpen && (
+        <div className="mt-1 p-3 rounded-lg bg-[#1e1e2e] border border-[#45475a] shadow-xl max-h-64 overflow-y-auto min-w-[180px]">
+          {/* Base node types */}
+          <div className="text-[10px] text-[#6c7086] uppercase tracking-wider mb-1.5 font-semibold">
+            Node Types
+          </div>
+          {BASE_TYPES.map((t) => (
+            <div key={t.label} className="flex items-center gap-2 mb-1">
+              <span
+                className="inline-block w-3.5 h-2.5 border-2 shrink-0"
+                style={{
+                  backgroundColor: t.bg,
+                  borderColor: t.color,
+                  borderRadius: t.shape === 'ellipse' ? '50%' : '2px',
+                }}
+              />
+              <span className="text-[11px] text-[#cdd6f4]">{t.label}</span>
+            </div>
+          ))}
+
+          {/* rdf:type colors */}
+          <div className="text-[10px] text-[#6c7086] uppercase tracking-wider mt-2.5 mb-1.5 font-semibold">
+            rdf:type
+          </div>
+          {Object.entries(TYPE_COLORS).map(([type, colors]) => (
+            <div key={type} className="flex items-center gap-2 mb-1">
+              <span
+                className="inline-block w-3.5 h-2.5 rounded-full border-2 shrink-0"
+                style={{
+                  backgroundColor: colors.bg,
+                  borderColor: colors.border,
+                }}
+              />
+              <span className="text-[11px] text-[#cdd6f4]">{colors.label}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/graph/RdfGraph.tsx
+++ b/src/components/graph/RdfGraph.tsx
@@ -1,9 +1,11 @@
-import { useEffect, useRef, useCallback } from 'react'
+import { useEffect, useRef, useCallback, useMemo } from 'react'
 import cytoscape from 'cytoscape'
 import coseBilkent from 'cytoscape-cose-bilkent'
 import { useRdfStore } from '../../store/rdfStore'
 import { useUiStore } from '../../store/uiStore'
+import { useDomainStore } from '../../store/domainStore'
 import { storeToCytoscape, CY_STYLE } from './graphUtils'
+import GraphLegend from './GraphLegend'
 
 cytoscape.use(coseBilkent)
 
@@ -15,6 +17,41 @@ export default function RdfGraph() {
   const prefixes = useRdfStore((s) => s.prefixes)
   const selectedNode = useUiStore((s) => s.selectedNode)
   const setSelectedNode = useUiStore((s) => s.setSelectedNode)
+  const activeDomainId = useDomainStore((s) => s.activeDomainId)
+  const registeredDomains = useDomainStore((s) => s.registeredDomains)
+
+  // Merge base CY_STYLE with active domain plugin graphStyles
+  const mergedStyle = useMemo(() => {
+    const domain = registeredDomains.get(activeDomainId)
+    if (!domain) return CY_STYLE
+
+    // Check if domain info has a graphStyles property (from DomainPlugin)
+    const domainWithStyles = domain as {
+      graphStyles?: { selector: string; style: Record<string, string | number> }[]
+    }
+    if (!domainWithStyles.graphStyles || domainWithStyles.graphStyles.length === 0) return CY_STYLE
+
+    // Insert domain styles before the :selected rules so they take precedence
+    // over base IRI styles but not over selection styles
+    const baseStyles = [...CY_STYLE]
+    const domainStyles = domainWithStyles.graphStyles.map((rule) => ({
+      selector: rule.selector,
+      style: rule.style,
+    }))
+
+    // Find the index of 'node:selected' to insert domain styles before it
+    const selectedIdx = baseStyles.findIndex(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (s: any) => s.selector === 'node:selected'
+    )
+    if (selectedIdx >= 0) {
+      baseStyles.splice(selectedIdx, 0, ...domainStyles)
+    } else {
+      baseStyles.push(...domainStyles)
+    }
+
+    return baseStyles
+  }, [activeDomainId, registeredDomains])
 
   // Initialize cytoscape once
   useEffect(() => {
@@ -23,7 +60,7 @@ export default function RdfGraph() {
     const cy = cytoscape({
       container: containerRef.current,
       elements: [],
-      style: CY_STYLE,
+      style: mergedStyle,
       userZoomingEnabled: true,
       userPanningEnabled: true,
       boxSelectionEnabled: false,
@@ -44,7 +81,7 @@ export default function RdfGraph() {
 
     cyRef.current = cy
     return () => cy.destroy()
-  }, [setSelectedNode])
+  }, [setSelectedNode, mergedStyle])
 
   // Update graph data when store changes
   useEffect(() => {
@@ -114,7 +151,7 @@ export default function RdfGraph() {
   const tripleCount = store.size
 
   return (
-    <div className="flex flex-col h-full">
+    <div className="flex flex-col h-full relative">
       {/* Toolbar */}
       <div className="flex items-center gap-2 px-3 py-1.5 border-b border-surface-raised text-xs">
         <button
@@ -137,6 +174,9 @@ export default function RdfGraph() {
 
       {/* Cytoscape container */}
       <div ref={containerRef} className="flex-1 w-full" />
+
+      {/* Legend overlay */}
+      <GraphLegend />
     </div>
   )
 }

--- a/src/components/graph/__tests__/graphUtils.test.ts
+++ b/src/components/graph/__tests__/graphUtils.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect } from 'vitest'
+import * as N3 from 'n3'
+import { storeToCytoscape, TYPE_COLORS } from '../graphUtils'
+
+const { namedNode, literal, quad } = N3.DataFactory
+
+function createStore(quads: N3.Quad[]): N3.Store {
+  const store = new N3.Store()
+  store.addQuads(quads)
+  return store
+}
+
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type'
+
+describe('storeToCytoscape', () => {
+  it('should create nodes and edges from simple triples', () => {
+    const store = createStore([
+      quad(
+        namedNode('http://example.org/Alice'),
+        namedNode('http://xmlns.com/foaf/0.1/name'),
+        literal('Alice')
+      ),
+    ])
+
+    const result = storeToCytoscape(store, {})
+    expect(result.nodes).toHaveLength(2)
+    expect(result.edges).toHaveLength(1)
+  })
+
+  it('should attach rdfType and rdfTypes for nodes with rdf:type', () => {
+    const store = createStore([
+      quad(
+        namedNode('http://example.org/Alice'),
+        namedNode(RDF_TYPE),
+        namedNode('http://xmlns.com/foaf/0.1/Person')
+      ),
+      quad(
+        namedNode('http://example.org/Alice'),
+        namedNode('http://xmlns.com/foaf/0.1/name'),
+        literal('Alice')
+      ),
+    ])
+
+    const result = storeToCytoscape(store, { foaf: 'http://xmlns.com/foaf/0.1/' })
+
+    const aliceNode = result.nodes.find((n) => n.data.id === 'http://example.org/Alice')
+    expect(aliceNode).toBeDefined()
+    expect(aliceNode!.data.rdfType).toBe('Person')
+    expect(aliceNode!.data.rdfTypes).toEqual(['http://xmlns.com/foaf/0.1/Person'])
+  })
+
+  it('should handle multiple rdf:type values', () => {
+    const store = createStore([
+      quad(
+        namedNode('http://example.org/Bob'),
+        namedNode(RDF_TYPE),
+        namedNode('http://xmlns.com/foaf/0.1/Person')
+      ),
+      quad(
+        namedNode('http://example.org/Bob'),
+        namedNode(RDF_TYPE),
+        namedNode('http://xmlns.com/foaf/0.1/Agent')
+      ),
+    ])
+
+    const result = storeToCytoscape(store, {})
+
+    const bobNode = result.nodes.find((n) => n.data.id === 'http://example.org/Bob')
+    expect(bobNode).toBeDefined()
+    expect(bobNode!.data.rdfTypes).toHaveLength(2)
+    expect(bobNode!.data.rdfTypes).toContain('http://xmlns.com/foaf/0.1/Person')
+    expect(bobNode!.data.rdfTypes).toContain('http://xmlns.com/foaf/0.1/Agent')
+    // Primary type is the first one encountered
+    expect(bobNode!.data.rdfType).toBe('Person')
+  })
+
+  it('should not attach rdfType to nodes without rdf:type', () => {
+    const store = createStore([
+      quad(namedNode('http://example.org/x'), namedNode('http://example.org/p'), literal('value')),
+    ])
+
+    const result = storeToCytoscape(store, {})
+
+    const xNode = result.nodes.find((n) => n.data.id === 'http://example.org/x')
+    expect(xNode).toBeDefined()
+    expect(xNode!.data.rdfType).toBeUndefined()
+    expect(xNode!.data.rdfTypes).toBeUndefined()
+  })
+
+  it('should not attach rdfType to literal or blank nodes', () => {
+    const store = createStore([
+      quad(namedNode('http://example.org/x'), namedNode('http://example.org/p'), literal('hello')),
+    ])
+
+    const result = storeToCytoscape(store, {})
+
+    const litNode = result.nodes.find((n) => n.data.nodeType === 'literal')
+    expect(litNode).toBeDefined()
+    expect(litNode!.data.rdfType).toBeUndefined()
+  })
+
+  it('should handle owl:Class type correctly', () => {
+    const store = createStore([
+      quad(
+        namedNode('http://example.org/MyClass'),
+        namedNode(RDF_TYPE),
+        namedNode('http://www.w3.org/2002/07/owl#Class')
+      ),
+    ])
+
+    const result = storeToCytoscape(store, {})
+
+    const node = result.nodes.find((n) => n.data.id === 'http://example.org/MyClass')
+    expect(node).toBeDefined()
+    expect(node!.data.rdfType).toBe('Class')
+  })
+
+  it('should shorten labels using prefixes', () => {
+    const store = createStore([
+      quad(
+        namedNode('http://example.org/x'),
+        namedNode('http://example.org/p'),
+        namedNode('http://example.org/y')
+      ),
+    ])
+
+    const result = storeToCytoscape(store, { ex: 'http://example.org/' })
+
+    const xNode = result.nodes.find((n) => n.data.id === 'http://example.org/x')
+    expect(xNode!.data.label).toBe('ex:x')
+  })
+
+  it('should handle blank nodes', () => {
+    const store = createStore([
+      quad(N3.DataFactory.blankNode('b0'), namedNode('http://example.org/p'), literal('value')),
+    ])
+
+    const result = storeToCytoscape(store, {})
+
+    const blankNode = result.nodes.find((n) => n.data.nodeType === 'blank')
+    expect(blankNode).toBeDefined()
+    expect(blankNode!.data.label).toMatch(/^_:/)
+  })
+
+  it('should cap at MAX_NODES (300)', () => {
+    const quads: N3.Quad[] = []
+    for (let i = 0; i < 400; i++) {
+      quads.push(
+        quad(
+          namedNode(`http://example.org/s${i}`),
+          namedNode('http://example.org/p'),
+          literal(`val${i}`)
+        )
+      )
+    }
+    const store = createStore(quads)
+
+    const result = storeToCytoscape(store, {})
+    // Each quad creates 2 nodes + 1 edge; capped at 300 quads
+    expect(result.edges.length).toBeLessThanOrEqual(300)
+  })
+})
+
+describe('TYPE_COLORS', () => {
+  it('should have entries for common RDF types', () => {
+    expect(TYPE_COLORS).toHaveProperty('Class')
+    expect(TYPE_COLORS).toHaveProperty('Person')
+    expect(TYPE_COLORS).toHaveProperty('Ontology')
+  })
+
+  it('should have bg and border colors for each entry', () => {
+    for (const [, colors] of Object.entries(TYPE_COLORS)) {
+      expect(colors.bg).toMatch(/^#[0-9a-f]{6}$/)
+      expect(colors.border).toMatch(/^#[0-9a-f]{6}$/)
+      expect(colors.label).toBeTruthy()
+    }
+  })
+})

--- a/src/components/graph/graphUtils.ts
+++ b/src/components/graph/graphUtils.ts
@@ -9,12 +9,43 @@ export interface CyElements {
 
 const MAX_NODES = 300 // Performance guard
 
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type'
+
+/**
+ * Extract the local name from a full IRI (after last '#' or '/').
+ */
+function localName(iri: string): string {
+  const sep = Math.max(iri.lastIndexOf('#'), iri.lastIndexOf('/'))
+  return sep >= 0 ? iri.slice(sep + 1) : iri
+}
+
+/**
+ * Build a map of subject IRI → rdf:type IRIs from the store.
+ */
+function buildTypeMap(store: N3.Store): Map<string, string[]> {
+  const typeMap = new Map<string, string[]>()
+  for (const quad of store.match(
+    null,
+    { termType: 'NamedNode', value: RDF_TYPE } as N3.NamedNode,
+    null
+  )) {
+    if (quad.object.termType === 'NamedNode') {
+      const types = typeMap.get(quad.subject.value) ?? []
+      types.push(quad.object.value)
+      typeMap.set(quad.subject.value, types)
+    }
+  }
+  return typeMap
+}
+
 /**
  * Convert N3.Store triples to Cytoscape elements.
  * Blank nodes and literals are represented as nodes.
  * Predicates become directed edges.
+ * rdf:type information is attached to each IRI node for type-based styling.
  */
 export function storeToCytoscape(store: N3.Store, prefixes: Record<string, string>): CyElements {
+  const typeMap = buildTypeMap(store)
   const nodeMap = new Map<string, CyNodeData>()
   const edges: { data: CyEdgeData }[] = []
   let edgeIdx = 0
@@ -26,7 +57,18 @@ export function storeToCytoscape(store: N3.Store, prefixes: Record<string, strin
     fullIri?: string
   ) => {
     if (!nodeMap.has(id)) {
-      nodeMap.set(id, { id, label, nodeType, fullIri })
+      const data: CyNodeData = { id, label, nodeType, fullIri }
+
+      // Attach rdf:type info for IRI nodes
+      if (nodeType === 'iri' && fullIri) {
+        const types = typeMap.get(fullIri)
+        if (types && types.length > 0) {
+          data.rdfTypes = types
+          data.rdfType = localName(types[0])
+        }
+      }
+
+      nodeMap.set(id, data)
     }
   }
 
@@ -79,8 +121,31 @@ export function storeToCytoscape(store: N3.Store, prefixes: Record<string, strin
   }
 }
 
+// ─── Type-based color definitions ──────────────────────────────────
+
+/** Exported for use in GraphLegend */
+export const TYPE_COLORS: Record<string, { bg: string; border: string; label: string }> = {
+  // OWL / RDFS meta types
+  Class: { bg: '#45275e', border: '#cba6f7', label: 'owl:Class / rdfs:Class' },
+  Ontology: { bg: '#3b1f3e', border: '#f38ba8', label: 'owl:Ontology' },
+  ObjectProperty: { bg: '#1a3a2a', border: '#a6e3a1', label: 'owl:ObjectProperty' },
+  DatatypeProperty: { bg: '#1a3835', border: '#94e2d5', label: 'owl:DatatypeProperty' },
+  // People / Org
+  Person: { bg: '#1a2e4a', border: '#89b4fa', label: 'foaf:Person / schema:Person' },
+  Organization: { bg: '#3a2a1a', border: '#fab387', label: 'foaf:Organization' },
+  // SKOS
+  Concept: { bg: '#3a3520', border: '#f9e2af', label: 'skos:Concept' },
+  ConceptScheme: { bg: '#3a3520', border: '#f9e2af', label: 'skos:ConceptScheme' },
+  // SAMM
+  Aspect: { bg: '#2e1a4e', border: '#b47ded', label: 'samm:Aspect' },
+  Property: { bg: '#1a2e4a', border: '#89b4fa', label: 'samm:Property / rdf:Property' },
+  Characteristic: { bg: '#1a3a2a', border: '#a6e3a1', label: 'samm:Characteristic' },
+  Entity: { bg: '#3a2a1a', border: '#fab387', label: 'samm:Entity' },
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const CY_STYLE: any[] = [
+  // ─── Base node style ──────────────────────────────────────────
   {
     selector: 'node',
     style: {
@@ -129,6 +194,18 @@ export const CY_STYLE: any[] = [
       color: '#f9e2af',
     },
   },
+
+  // ─── rdf:type-based node styling ──────────────────────────────
+  ...Object.entries(TYPE_COLORS).map(([type, colors]) => ({
+    selector: `node[rdfType="${type}"]`,
+    style: {
+      'background-color': colors.bg,
+      'border-color': colors.border,
+      'border-width': 2.5,
+    },
+  })),
+
+  // ─── Selection ────────────────────────────────────────────────
   {
     selector: 'node:selected',
     style: {
@@ -137,6 +214,8 @@ export const CY_STYLE: any[] = [
       'background-color': '#313244',
     },
   },
+
+  // ─── Edge styles ──────────────────────────────────────────────
   {
     selector: 'edge',
     style: {

--- a/src/lib/samm/sammPlugin.ts
+++ b/src/lib/samm/sammPlugin.ts
@@ -268,31 +268,31 @@ export const sammPlugin: DomainPlugin = {
 
   graphStyles: [
     {
-      selector: 'node[label = "samm:Aspect"]',
+      selector: 'node[rdfType = "Aspect"]',
       style: {
-        'background-color': '#7c3aed',
-        'border-color': '#6d28d9',
+        'background-color': '#2e1a4e',
+        'border-color': '#b47ded',
       },
     },
     {
-      selector: 'node[label = "samm:Property"]',
+      selector: 'node[rdfType = "Property"]',
       style: {
-        'background-color': '#2563eb',
-        'border-color': '#1d4ed8',
+        'background-color': '#1a2e4a',
+        'border-color': '#89b4fa',
       },
     },
     {
-      selector: 'node[label = "samm:Characteristic"]',
+      selector: 'node[rdfType = "Characteristic"]',
       style: {
-        'background-color': '#059669',
-        'border-color': '#047857',
+        'background-color': '#1a3a2a',
+        'border-color': '#a6e3a1',
       },
     },
     {
-      selector: 'node[label = "samm:Entity"]',
+      selector: 'node[rdfType = "Entity"]',
       style: {
-        'background-color': '#d97706',
-        'border-color': '#b45309',
+        'background-color': '#3a2a1a',
+        'border-color': '#fab387',
       },
     },
   ],

--- a/src/types/rdf.ts
+++ b/src/types/rdf.ts
@@ -93,6 +93,10 @@ export interface CyNodeData {
   label: string
   nodeType: 'iri' | 'literal' | 'blank'
   fullIri?: string
+  /** Full IRIs of all rdf:type values for this node */
+  rdfTypes?: string[]
+  /** Local name of the primary rdf:type (e.g. "Class", "Person") for selector matching */
+  rdfType?: string
 }
 
 export interface CyEdgeData {


### PR DESCRIPTION
## 概要

ノードの `rdf:type` に応じて色を自動変更するスタイルルールを追加し、グラフの可読性を向上させる。

## 変更内容

### 1. rdf:type の抽出 (`graphUtils.ts`)
- `buildTypeMap()` で Store から `rdf:type` トリプルを収集
- `storeToCytoscape()` で各 IRI ノードに `rdfTypes` (全タイプ配列) と `rdfType` (プライマリタイプのローカル名) を付与

### 2. タイプ別スタイリング (Catppuccin Mocha パレット)
| rdf:type | 色 |
|---|---|
| owl:Class / rdfs:Class | Mauve |
| owl:Ontology | Red |
| owl:ObjectProperty | Green |
| owl:DatatypeProperty | Teal |
| foaf:Person / schema:Person | Blue |
| foaf:Organization | Peach |
| skos:Concept | Yellow |
| SAMM types | Purple/Blue/Green/Peach |

### 3. ドメインプラグイン連携 (`RdfGraph.tsx`)
- `domainStore` の `graphStyles` を `CY_STYLE` にマージして Cytoscape に適用
- SAMM プラグインのセレクタを `rdfType` データ属性ベースに修正

### 4. 凡例コンポーネント (`GraphLegend.tsx`)
- グラフ左下にトグル式の凡例オーバーレイを追加
- ノードタイプ (IRI/Blank/Literal) と rdf:type 別カラーを表示

### 5. テスト (`graphUtils.test.ts`)
- 11 件のユニットテストを追加 (rdf:type 抽出、複数タイプ、MAX_NODES cap 等)

## テスト結果
- ✅ Lint: 0 errors
- ✅ TypeCheck: clean
- ✅ Unit Tests: 122 passed (11 new)
- ✅ ブラウザ確認: FOAF / SAMM テンプレートでノード色分け＆凡例動作確認済

Closes #9