### PR TITLE
[OPS-3] Add .github/dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  # npm packages
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary

Add Dependabot configuration to enable automated version-update PRs for npm packages and GitHub Actions.

## Changes

- Created `.github/dependabot.yml` with:
  - **npm** ecosystem: weekly updates (Monday 09:00 JST), dev-dependency minor/patch grouped
  - **GitHub Actions** ecosystem: weekly updates (Monday 09:00 JST)
  - `open-pull-requests-limit: 5` for both ecosystems

## Why

- **Security**: Dependabot will open PRs when vulnerable dependencies are detected
- **SHA pinning maintenance**: Once Actions are SHA-pinned (OPS-4), Dependabot will automatically update those SHAs
- **Noise reduction**: Dev dependency minor/patch updates are grouped into single PRs

## Acceptance Criteria

- [x] `.github/dependabot.yml` exists with both `npm` and `github-actions` ecosystems
- [x] Schedule is weekly on Monday at 09:00 Asia/Tokyo
- [x] Dev dependencies are grouped for npm
- [x] `open-pull-requests-limit: 5` is set for both ecosystems

Closes #38