### PR TITLE
[OPS-5] Fix claude-code-review.yml — replace placeholder usernames in if condition

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,11 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
+    # Only run for non-maintainer contributors
     if: |
-      github.event.pull_request.user.login == 'external-contributor' ||
-      github.event.pull_request.user.login == 'new-developer' ||
-      github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+      github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' ||
+      github.event.pull_request.author_association == 'CONTRIBUTOR' ||
+      github.event.pull_request.author_association == 'NONE'
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary

Fix the broken `if` condition in the Claude Code Review workflow that checked for placeholder usernames that would never match real contributors.

## Changes

**Before** (broken):
```yaml
if: |
  github.event.pull_request.user.login == 'external-contributor' ||
  github.event.pull_request.user.login == 'new-developer' ||
  github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
```

**After** (fixed):
```yaml
if: |
  github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' ||
  github.event.pull_request.author_association == 'CONTRIBUTOR' ||
  github.event.pull_request.author_association == 'NONE'
```

## Why

- The old condition used literal usernames `external-contributor` and `new-developer` — placeholders that never match real users
- The new condition uses `author_association` which is the correct, maintainable approach
- Covers all non-maintainer associations: `FIRST_TIME_CONTRIBUTOR`, `CONTRIBUTOR`, `NONE`
- Skips `OWNER`, `MEMBER`, `COLLABORATOR` PRs (maintainers)

## Acceptance Criteria

- [x] Placeholder username conditions removed
- [x] Condition covers `FIRST_TIME_CONTRIBUTOR`, `CONTRIBUTOR`, and `NONE`
- [x] Workflow correctly skips for repo owner's own PRs
- [x] Logic verified by inspection

Closes #40