### PR TITLE
fix(ci): pin Actions to SHA and add quality gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,25 +12,31 @@ jobs:
     permissions:
       contents: read
     steps:
-    - uses: actions/checkout@v4
-    
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
       with:
         node-version: '20'
         cache: 'npm'
-        
+
     - name: Install Dependencies
-      run: npm install
+      run: npm ci
 
     - name: Run Type Check
-      run: npm run build
-      
+      run: npm run typecheck
+
+    - name: Run Lint
+      run: npm run lint
+
+    - name: Run Format Check
+      run: npm run format:check
+
     - name: Run Unit Tests
       run: npm run test
-      
+
     - name: Install Playwright Browsers
       run: npx playwright install --with-deps chromium
-      
+
     - name: Run E2E Tests
       run: npx playwright test --project=chromium

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,13 +26,13 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@26ec041249acb0a944c0a47b6c0c13f05dbc5b44 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 


### PR DESCRIPTION
- Pin actions/checkout and actions/setup-node to full commit SHAs in ci.yml
- Pin anthropics/claude-code-action to full commit SHA in claude.yml
- Replace npm install with npm ci for lockfile compliance
- Replace npm run build with npm run typecheck for type checking
- Add npm run lint and npm run format:check as quality gates

Closes #39

https://claude.ai/code/session_01P6wYeATwTikAduFvF3NFP7