### PR TITLE
fix(ci): exclude bot actors from Claude code review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,14 @@ on:
 
 jobs:
   claude-review:
-    # Only run for non-maintainer contributors
+    # Only run for non-maintainer human contributors (skip bots like Dependabot)
     if: |
-      github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' ||
-      github.event.pull_request.author_association == 'CONTRIBUTOR' ||
-      github.event.pull_request.author_association == 'NONE'
+      github.event.pull_request.user.type != 'Bot' &&
+      (
+        github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' ||
+        github.event.pull_request.author_association == 'CONTRIBUTOR' ||
+        github.event.pull_request.author_association == 'NONE'
+      )
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary

Exclude bot actors (like Dependabot) from the Claude Code Review workflow to prevent CI failures on automated PRs.

## Problem

Dependabot PRs have `author_association: 'NONE'` which matches the `if` condition and triggers the review job. However, the Claude Code Review action itself rejects non-human actors, causing the job to fail with:
> Workflow initiated by non-human actor: dependabot (type: Bot)

This causes PRs #44 and #45 to show red CI.

## Fix

Add `github.event.pull_request.user.type != 'Bot'` to the `if` condition to skip bot-created PRs at the workflow level.

## Affected PRs

Once merged, rebasing PRs #44 and #45 will pick up this fix.