### PR TITLE
feat: add GitHub Pages release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,113 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g. v1.2.3) — for reference only, tag must already exist'
+        required: false
+
+# Deny all permissions by default; grant only what each job needs
+permissions: {}
+
+jobs:
+  # ─────────────────────────────────────────────
+  # Job 1: Full CI gate
+  # ─────────────────────────────────────────────
+  ci:
+    name: CI
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Type check
+        run: npm run typecheck
+
+      - name: Unit tests
+        run: npm run test:run
+
+      - name: Build
+        run: npm run build
+
+      - name: Upload dist artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: dist
+          path: dist/
+          retention-days: 1
+
+  # ─────────────────────────────────────────────
+  # Job 2: Deploy to GitHub Pages
+  # ─────────────────────────────────────────────
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: ci
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+      - name: Download dist artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
+        with:
+          path: dist/
+
+      - name: Deploy to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
+
+  # ─────────────────────────────────────────────
+  # Job 3: Create GitHub Release
+  # ─────────────────────────────────────────────
+  release:
+    name: Create GitHub Release
+    needs: deploy
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Download dist artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Zip dist
+        run: zip -r dist.zip dist/
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            --generate-notes \
+            --title "${{ github.ref_name }}" \
+            dist.zip

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,7 +2,13 @@
 import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 
+// When deploying to GitHub Pages (https://ryo-shoji164.github.io/rdf-editor/),
+// the base path must match the repository name.
+// GITHUB_ACTIONS env var is set automatically in all GitHub Actions runs.
+const base = process.env.GITHUB_ACTIONS ? '/rdf-editor/' : '/'
+
 export default defineConfig({
+  base,
   plugins: [react()],
   optimizeDeps: {
     include: ['n3', 'cytoscape', 'cytoscape-cose-bilkent'],


### PR DESCRIPTION
## 概要

タグを push するだけでビルド・デプロイ・GitHub Release 作成が自動実行されるリリースパイプラインを構築しました。

## 変更内容

### `vite.config.ts`
GitHub Actions 環境でのみ `base: '/rdf-editor/'` を設定します。  
ローカル開発時は `base: '/'` のままなので影響なし。

```ts
const base = process.env.GITHUB_ACTIONS ? '/rdf-editor/' : '/'
```

### `.github/workflows/release.yml`

`v*.*.*` タグの push（または手動実行）で起動する3ジョブのパイプライン：

| ジョブ | 内容 |
|---|---|
| **CI** | `npm ci` → lint → typecheck → unit tests → build → dist をアーティファクト保存 |
| **Deploy** | dist を GitHub Pages にデプロイ |
| **Release** | dist.zip を添付して GitHub Release を自動作成（changelog 自動生成） |

全アクションをコミット SHA でピン留め済み。

## リリース手順

```bash
# バージョンを上げてタグを作成・push するだけ
npm version patch   # または minor / major
git push origin main --tags
```

→ 自動でCI→デプロイ→GitHub Release が作成されます。

## GitHub Pages 設定

PR マージ後、初回リリースタグを push するとデプロイされます。  
URL: https://ryo-shoji164.github.io/rdf-editor/

（GitHub Pages の Source を「GitHub Actions」に設定済み）