### PR TITLE
feat: add i18n support (English and Japanese)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-i18next": "^16.5.6",
+        "use-sync-external-store": "^1.6.0",
         "zustand": "^5.0.11"
       },
       "devDependencies": {
@@ -6103,7 +6104,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
       "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
-      "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-i18next": "^16.5.6",
+    "use-sync-external-store": "^1.6.0",
     "zustand": "^5.0.11"
   },
   "devDependencies": {

--- a/src/components/graph/AddEdgeDialog.tsx
+++ b/src/components/graph/AddEdgeDialog.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
 
 interface AddEdgeDialogProps {
   isOpen: boolean
@@ -13,7 +14,9 @@ export default function AddEdgeDialog({
   onClose,
   onSubmit,
 }: AddEdgeDialogProps) {
+  const { t } = useTranslation()
   const [predicate, setPredicate] = useState('http://example.org/predicate')
+
   const [object, setObject] = useState('')
   const [isLiteral, setIsLiteral] = useState(false)
 
@@ -43,21 +46,26 @@ export default function AddEdgeDialog({
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
       <div className="bg-surface border border-surface-raised rounded-lg shadow-xl w-full max-w-md overflow-hidden">
         <div className="px-5 py-4 border-b border-surface-raised flex justify-between items-center bg-surface-raised/30">
-          <h2 className="text-lg font-medium text-text-primary">Add Edge (Triple)</h2>
+          <h2 className="text-lg font-medium text-text-primary">{t('dialogs.addEdge.title')}</h2>
           <button onClick={handleCloseWrapper} className="text-text-muted hover:text-text-primary">
             ✕
           </button>
         </div>
 
         <form onSubmit={handleSubmit} className="p-5 space-y-4">
-          <div className="text-sm bg-editor p-3 rounded border border-surface-raised mb-4">
-            <span className="text-text-secondary">Source (Subject):</span>
-            <div className="font-mono text-accent-cyan break-all mt-1">{displaySource}</div>
+          {/* Source Node (Read-only) */}
+          <div>
+            <label className="block text-sm font-medium text-text-secondary mb-1">
+              {t('dialogs.addEdge.fromNode')}
+            </label>
+            <div className="w-full bg-surface-alt text-text-muted border border-surface-raised rounded px-3 py-2 text-sm font-mono break-all">
+              {displaySource}
+            </div>
           </div>
 
           <div>
             <label className="block text-sm font-medium text-text-secondary mb-1">
-              Predicate (Property/Edge) <span className="text-accent-blue">*</span>
+              {t('dialogs.addEdge.predicateLabel')} <span className="text-accent-blue">*</span>
             </label>
             <input
               type="text"
@@ -72,7 +80,7 @@ export default function AddEdgeDialog({
           <div>
             <div className="flex justify-between items-end mb-1">
               <label className="block text-sm font-medium text-text-secondary">
-                Object (Target) <span className="text-accent-blue">*</span>
+                {t('dialogs.addEdge.objValue')} <span className="text-accent-blue">*</span>
               </label>
               <label className="flex items-center gap-1.5 text-xs text-text-primary cursor-pointer">
                 <input
@@ -81,7 +89,7 @@ export default function AddEdgeDialog({
                   onChange={(e) => setIsLiteral(e.target.checked)}
                   className="rounded border-surface-raised bg-editor text-accent-blue focus:ring-accent-blue focus:ring-offset-surface"
                 />
-                Is Literal Value
+                {t('dialogs.addEdge.literalObj')}
               </label>
             </div>
             <input
@@ -100,14 +108,14 @@ export default function AddEdgeDialog({
               onClick={handleCloseWrapper}
               className="px-4 py-2 rounded text-sm font-medium text-text-secondary hover:bg-surface-raised"
             >
-              Cancel
+              {t('dialogs.addEdge.cancel')}
             </button>
             <button
               type="submit"
               disabled={!predicate.trim() || !object.trim()}
               className="px-4 py-2 rounded text-sm font-medium bg-accent-blue text-white hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
             >
-              Add Edge
+              {t('dialogs.addEdge.add')}
             </button>
           </div>
         </form>

--- a/src/components/graph/AddNodeDialog.tsx
+++ b/src/components/graph/AddNodeDialog.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
 
 interface AddNodeDialogProps {
   isOpen: boolean
@@ -7,6 +8,7 @@ interface AddNodeDialogProps {
 }
 
 export default function AddNodeDialog({ isOpen, onClose, onSubmit }: AddNodeDialogProps) {
+  const { t } = useTranslation()
   const [iri, setIri] = useState('http://example.org/NewNode')
   const [label, setLabel] = useState('')
 
@@ -29,7 +31,7 @@ export default function AddNodeDialog({ isOpen, onClose, onSubmit }: AddNodeDial
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
       <div className="bg-surface border border-surface-raised rounded-lg shadow-xl w-full max-w-md overflow-hidden">
         <div className="px-5 py-4 border-b border-surface-raised flex justify-between items-center bg-surface-raised/30">
-          <h2 className="text-lg font-medium text-text-primary">Add New Node</h2>
+          <h2 className="text-lg font-medium text-text-primary">{t('dialogs.addNode.title')}</h2>
           <button onClick={handleCloseWrapper} className="text-text-muted hover:text-text-primary">
             ✕
           </button>
@@ -38,7 +40,7 @@ export default function AddNodeDialog({ isOpen, onClose, onSubmit }: AddNodeDial
         <form onSubmit={handleSubmit} className="p-5 space-y-4">
           <div>
             <label className="block text-sm font-medium text-text-secondary mb-1">
-              Node IRI <span className="text-accent-blue">*</span>
+              {t('dialogs.addNode.nodeIri')} <span className="text-accent-blue">*</span>
             </label>
             <input
               type="text"
@@ -46,21 +48,23 @@ export default function AddNodeDialog({ isOpen, onClose, onSubmit }: AddNodeDial
               value={iri}
               onChange={(e) => setIri(e.target.value)}
               className="w-full bg-editor text-text-primary border border-surface-raised rounded px-3 py-2 text-sm focus:outline-none focus:border-accent-blue focus:ring-1 focus:ring-accent-blue"
-              placeholder="http://example.org/MyNode or ex:MyNode"
+              placeholder={t('dialogs.addNode.iriPlaceholder')}
             />
           </div>
 
           <div>
             <label className="block text-sm font-medium text-text-secondary mb-1">
-              Label (rdfs:label){' '}
-              <span className="text-text-muted text-xs font-normal">Optional</span>
+              {t('dialogs.addNode.label')}{' '}
+              <span className="text-text-muted text-xs font-normal">
+                {t('dialogs.addNode.optional')}
+              </span>
             </label>
             <input
               type="text"
               value={label}
               onChange={(e) => setLabel(e.target.value)}
               className="w-full bg-editor text-text-primary border border-surface-raised rounded px-3 py-2 text-sm focus:outline-none focus:border-accent-blue focus:ring-1 focus:ring-accent-blue"
-              placeholder="Human readable display name"
+              placeholder={t('dialogs.addNode.labelPlaceholder')}
             />
           </div>
 
@@ -70,14 +74,14 @@ export default function AddNodeDialog({ isOpen, onClose, onSubmit }: AddNodeDial
               onClick={handleCloseWrapper}
               className="px-4 py-2 rounded text-sm font-medium text-text-secondary hover:bg-surface-raised"
             >
-              Cancel
+              {t('dialogs.addNode.cancel')}
             </button>
             <button
               type="submit"
               disabled={!iri.trim()}
               className="px-4 py-2 rounded text-sm font-medium bg-accent-blue text-white hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
             >
-              Add Node
+              {t('dialogs.addNode.add')}
             </button>
           </div>
         </form>

--- a/src/components/graph/GraphContextMenu.tsx
+++ b/src/components/graph/GraphContextMenu.tsx
@@ -1,26 +1,29 @@
 import { useEffect, useRef } from 'react'
+import { Plus, Link2 } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
 
 export type ContextMenuTargetType = 'bg' | 'node' | null
 
 interface GraphContextMenuProps {
   isOpen: boolean
-  x: number
-  y: number
+  position: { x: number; y: number }
   targetType: ContextMenuTargetType
+  targetId?: string
   onClose: () => void
-  onAddNode: () => void
-  onAddEdge: () => void
+  onAddNode: (position: { x: number; y: number }) => void
+  onAddEdgeFromCurrent: (sourceNodeId: string) => void
 }
 
 export default function GraphContextMenu({
   isOpen,
-  x,
-  y,
+  position,
   targetType,
-  onClose,
+  targetId,
   onAddNode,
-  onAddEdge,
+  onAddEdgeFromCurrent,
+  onClose,
 }: GraphContextMenuProps) {
+  const { t } = useTranslation()
   const menuRef = useRef<HTMLDivElement>(null)
 
   // Close when clicking outside
@@ -51,30 +54,34 @@ export default function GraphContextMenu({
     <div
       ref={menuRef}
       className="absolute z-50 bg-surface border border-surface-raised rounded-md shadow-lg py-1 min-w-[150px] text-sm"
-      style={{ top: y, left: x }}
+      style={{ top: position.y, left: position.x }}
       onContextMenu={(e) => e.preventDefault()}
     >
       {targetType === 'bg' && (
         <button
-          className="w-full text-left px-4 py-2 hover:bg-surface-raised text-text-primary transition-colors"
           onClick={() => {
-            onAddNode()
+            onAddNode(position)
             onClose()
           }}
+          className="w-full text-left px-3 py-2 text-sm text-text-primary hover:bg-surface-raised flex items-center gap-2 group transition-colors"
         >
-          Add Node...
+          <Plus size={14} className="text-text-muted group-hover:text-text-primary" />
+          {t('contextMenu.addNode')}
         </button>
       )}
 
       {targetType === 'node' && (
         <button
-          className="w-full text-left px-4 py-2 hover:bg-surface-raised text-text-primary transition-colors"
           onClick={() => {
-            onAddEdge()
+            if (targetId) {
+              onAddEdgeFromCurrent(targetId)
+            }
             onClose()
           }}
+          className="w-full text-left px-3 py-2 text-sm text-text-primary hover:bg-surface-raised flex items-center gap-2 group transition-colors"
         >
-          Add Edge from Here...
+          <Link2 size={14} className="text-text-muted group-hover:text-text-primary" />
+          {t('contextMenu.addEdge')}
         </button>
       )}
     </div>

--- a/src/components/graph/RdfGraph.tsx
+++ b/src/components/graph/RdfGraph.tsx
@@ -252,15 +252,15 @@ export default function RdfGraph() {
       {/* Context Menu and Dialogs */}
       <GraphContextMenu
         isOpen={menuOpen}
-        x={menuPos.x}
-        y={menuPos.y}
+        position={menuPos}
         targetType={menuTarget}
+        targetId={menuNodeId || undefined}
         onClose={() => setMenuOpen(false)}
         onAddNode={() => {
           setMenuOpen(false)
           setIsAddNodeOpen(true)
         }}
-        onAddEdge={() => {
+        onAddEdgeFromCurrent={() => {
           setMenuOpen(false)
           setIsAddEdgeOpen(true)
         }}

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -1,5 +1,6 @@
 import { useRef } from 'react'
 import { Code2, Network, Table2, Columns2, FileDown, FileUp, Trash2, Layers } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
 import { useRdfStore } from '../../store/rdfStore'
 import { useUiStore, type ActiveView } from '../../store/uiStore'
 import { useDomainStore } from '../../store/domainStore'
@@ -10,14 +11,16 @@ import SammPanel from '../samm/SammPanel'
 import StatusBar from './StatusBar'
 import TemplateMenu from './TemplateMenu'
 
-const VIEW_BUTTONS: { id: ActiveView; icon: React.ReactNode; label: string }[] = [
-  { id: 'editor', icon: <Code2 size={15} />, label: 'Editor' },
-  { id: 'graph', icon: <Network size={15} />, label: 'Graph' },
-  { id: 'table', icon: <Table2 size={15} />, label: 'Table' },
-  { id: 'split', icon: <Columns2 size={15} />, label: 'Split' },
+const VIEW_BUTTONS: { id: ActiveView; icon: React.ReactNode }[] = [
+  { id: 'editor', icon: <Code2 size={15} /> },
+  { id: 'graph', icon: <Network size={15} /> },
+  { id: 'table', icon: <Table2 size={15} /> },
+  { id: 'split', icon: <Columns2 size={15} /> },
 ]
 
 export default function AppLayout() {
+  const { t, i18n } = useTranslation()
+
   const activeView = useUiStore((s) => s.activeView)
   const setActiveView = useUiStore((s) => s.setActiveView)
 
@@ -89,7 +92,7 @@ export default function AppLayout() {
         {/* App name */}
         <div className="flex items-center gap-1.5 mr-3">
           <Layers size={16} className="text-accent-purple" />
-          <span className="text-sm font-medium text-text-primary">RDF Editor</span>
+          <span className="text-sm font-medium text-text-primary">{t('layout.title')}</span>
         </div>
 
         {/* Mode toggle — dynamically generated from registered domains */}
@@ -118,7 +121,7 @@ export default function AppLayout() {
               <button
                 key={btn.id}
                 onClick={() => setActiveView(btn.id)}
-                title={btn.label}
+                title={t(`layout.${btn.id}`)}
                 className={`px-2.5 py-1 flex items-center gap-1 text-xs transition-colors ${
                   activeView === btn.id
                     ? 'bg-surface-raised text-text-primary'
@@ -126,7 +129,7 @@ export default function AppLayout() {
                 }`}
               >
                 {btn.icon}
-                <span className="hidden sm:inline">{btn.label}</span>
+                <span className="hidden sm:inline">{t(`layout.${btn.id}`)}</span>
               </button>
             ))}
           </div>
@@ -135,6 +138,15 @@ export default function AppLayout() {
         <div className="ml-auto flex items-center gap-1">
           {/* Examples — dynamically generated from registered domains */}
           <TemplateMenu />
+
+          {/* Language Switcher */}
+          <button
+            onClick={() => i18n.changeLanguage(i18n.language.startsWith('ja') ? 'en' : 'ja')}
+            title="Toggle Language"
+            className="flex items-center gap-1 px-2.5 py-1 text-xs font-medium text-text-muted hover:text-text-primary hover:bg-surface-raised rounded mr-1"
+          >
+            {i18n.language.startsWith('ja') ? 'EN' : 'JA'}
+          </button>
 
           {/* Import */}
           <input
@@ -146,18 +158,18 @@ export default function AppLayout() {
           />
           <button
             onClick={() => fileInputRef.current?.click()}
-            title="Open file (.ttl, .nt, .jsonld)"
+            title={t('layout.open')}
             className="flex items-center gap-1 px-2.5 py-1 text-xs text-text-muted hover:text-text-primary hover:bg-surface-raised rounded"
           >
             <FileUp size={13} />
-            <span className="hidden sm:inline">Open</span>
+            <span className="hidden sm:inline">{t('layout.open')}</span>
           </button>
 
           {/* Export */}
           <div className="relative group">
             <button className="flex items-center gap-1 px-2.5 py-1 text-xs text-text-muted hover:text-text-primary hover:bg-surface-raised rounded">
               <FileDown size={13} />
-              <span className="hidden sm:inline">Export</span>
+              <span className="hidden sm:inline">{t('layout.export')}</span>
             </button>
             <div className="hidden group-hover:flex flex-col absolute right-0 top-full mt-1 bg-surface-raised border border-surface-raised rounded shadow-lg z-50 min-w-36">
               <button
@@ -184,7 +196,7 @@ export default function AppLayout() {
           {/* Clear */}
           <button
             onClick={clearAll}
-            title="Clear all"
+            title={t('layout.clearAll')}
             className="flex items-center gap-1 px-2.5 py-1 text-xs text-text-muted hover:text-accent-red hover:bg-surface-raised rounded"
           >
             <Trash2 size={13} />

--- a/src/lib/i18n/i18n.ts
+++ b/src/lib/i18n/i18n.ts
@@ -1,0 +1,33 @@
+import i18n from 'i18next'
+import { initReactI18next } from 'react-i18next'
+import LanguageDetector from 'i18next-browser-languagedetector'
+
+import en from './locales/en.json'
+import ja from './locales/ja.json'
+
+const resources = {
+  en: {
+    translation: en,
+  },
+  ja: {
+    translation: ja,
+  },
+}
+
+i18n
+  // detect user language
+  // learn more: https://github.com/i18next/i18next-browser-languageDetector
+  .use(LanguageDetector)
+  // pass the i18n instance to react-i18next.
+  .use(initReactI18next)
+  // init i18next
+  // for all options read: https://www.i18next.com/overview/configuration-options
+  .init({
+    resources,
+    fallbackLng: 'en',
+    interpolation: {
+      escapeValue: false, // not needed for react as it escapes by default
+    },
+  })
+
+export default i18n

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -1,0 +1,38 @@
+{
+    "layout": {
+        "title": "RDF Editor",
+        "editor": "Editor",
+        "graph": "Graph",
+        "table": "Table",
+        "split": "Split",
+        "open": "Open",
+        "export": "Export",
+        "exportTooltip": "Export as {{format}}",
+        "clearAll": "Clear all"
+    },
+    "dialogs": {
+        "addNode": {
+            "title": "Add New Node",
+            "nodeIri": "Node IRI",
+            "label": "Label (rdfs:label)",
+            "optional": "Optional",
+            "cancel": "Cancel",
+            "add": "Add Node",
+            "iriPlaceholder": "http://example.org/MyNode or ex:MyNode",
+            "labelPlaceholder": "Human readable display name"
+        },
+        "addEdge": {
+            "title": "Add Edge (Triple)",
+            "fromNode": "From Node:",
+            "predicate": "Predicate (URI)",
+            "literalObj": "Literal Object",
+            "objValue": "Object Value (IRI or Text)",
+            "cancel": "Cancel",
+            "add": "Add Edge"
+        }
+    },
+    "contextMenu": {
+        "addNode": "Add Node...",
+        "addEdge": "Add Edge from Here..."
+    }
+}

--- a/src/lib/i18n/locales/ja.json
+++ b/src/lib/i18n/locales/ja.json
@@ -1,0 +1,38 @@
+{
+    "layout": {
+        "title": "RDF Editor",
+        "editor": "エディタ",
+        "graph": "グラフ",
+        "table": "テーブル",
+        "split": "分割表示",
+        "open": "開く",
+        "export": "エクスポート",
+        "exportTooltip": "{{format}} 形式でエクスポート",
+        "clearAll": "すべてクリア"
+    },
+    "dialogs": {
+        "addNode": {
+            "title": "新規ノードの追加",
+            "nodeIri": "ノードIRI",
+            "label": "ラベル (rdfs:label)",
+            "optional": "任意",
+            "cancel": "キャンセル",
+            "add": "ノードを追加",
+            "iriPlaceholder": "http://example.org/MyNode または ex:MyNode",
+            "labelPlaceholder": "人間が読める表示名"
+        },
+        "addEdge": {
+            "title": "エッジ (トリプル) の追加",
+            "fromNode": "起点ノード:",
+            "predicate": "述語 (URI)",
+            "literalObj": "リテラル値にする",
+            "objValue": "目的語の値 (IRI またはテキスト)",
+            "cancel": "キャンセル",
+            "add": "エッジを追加"
+        }
+    },
+    "contextMenu": {
+        "addNode": "ノードを追加...",
+        "addEdge": "ここからエッジを伸ばす..."
+    }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client'
 import App from './App'
 import './index.css'
 import { initializeDomains } from './store/initDomains'
+import './lib/i18n/i18n'
 
 // Register built-in domains and load default content
 initializeDomains()

--- a/tests/e2e/i18n.spec.ts
+++ b/tests/e2e/i18n.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Internationalization (i18n)', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto('/');
+        // Wait for app to load initially
+        await expect(page.getByRole('button', { name: /Editor|エディタ/i })).toBeVisible();
+    });
+
+    test('switches language between English and Japanese', async ({ page }) => {
+        // Find the language toggle button. It should initially display "JA" when in English, or "EN" when in Japanese.
+        // The default fallback is English, but browser language might be Japanese.
+        const langToggle = page.getByTitle('Toggle Language');
+        await expect(langToggle).toBeVisible();
+
+        let initialLang = await langToggle.textContent();
+        initialLang = initialLang?.trim() || '';
+
+        if (initialLang === 'JA') {
+            // Currently in English, should see "Editor"
+            await expect(page.getByRole('button', { name: 'Editor', exact: true })).toBeVisible();
+            await expect(page.getByRole('button', { name: 'Graph', exact: true })).toBeVisible();
+            await expect(page.getByRole('button', { name: 'Table', exact: true })).toBeVisible();
+            await expect(page.getByRole('button', { name: 'Split', exact: true })).toBeVisible();
+
+            // Toggle to Japanese
+            await langToggle.click();
+
+            // Now we should see "エディタ" and the toggle should say "EN"
+            await expect(page.getByRole('button', { name: 'エディタ', exact: true })).toBeVisible();
+            await expect(page.getByRole('button', { name: 'グラフ', exact: true })).toBeVisible();
+            await expect(page.getByRole('button', { name: 'テーブル', exact: true })).toBeVisible();
+            await expect(page.getByRole('button', { name: '分割表示', exact: true })).toBeVisible();
+
+            await expect(langToggle).toHaveText('EN');
+
+            // Toggle back to English
+            await langToggle.click();
+            await expect(page.getByRole('button', { name: 'Editor', exact: true })).toBeVisible();
+            await expect(langToggle).toHaveText('JA');
+        } else {
+            // Currently in Japanese, should see "エディタ"
+            await expect(page.getByRole('button', { name: 'エディタ', exact: true })).toBeVisible();
+
+            // Toggle to English
+            await langToggle.click();
+
+            // Now we should see "Editor" and the toggle should say "JA"
+            await expect(page.getByRole('button', { name: 'Editor', exact: true })).toBeVisible();
+            await expect(langToggle).toHaveText('JA');
+
+            // Toggle back to Japanese
+            await langToggle.click();
+            await expect(page.getByRole('button', { name: 'エディタ', exact: true })).toBeVisible();
+            await expect(langToggle).toHaveText('EN');
+        }
+    });
+});


### PR DESCRIPTION
# Description

This PR implements internationalization (i18n) support for the RDF Editor.
- Adds `react-i18next` and browser language detection.
- Provides `en.json` and `ja.json` locales.
- Adds a Language Switcher to the header.
- Translates all major UI components (Editor tabs, Graph Context Menu, Node/Edge Dialogs).
- Adds an E2E test to verify language switching.