### PR TITLE
feat: implement inline table editing (A-2)

### DIFF
--- a/src/components/table/TripleTable.tsx
+++ b/src/components/table/TripleTable.tsx
@@ -1,8 +1,9 @@
-import { useMemo, useState } from 'react'
+import { useMemo, useState, useRef, useEffect } from 'react'
 import { useRdfStore } from '../../store/rdfStore'
 import { useUiStore } from '../../store/uiStore'
 import { storeToTriples } from '../../lib/rdf/store'
-import { shorten } from '../../lib/rdf/namespaces'
+import { updateTriple } from '../../lib/rdf/storeWriter'
+import { shorten, expand } from '../../lib/rdf/namespaces'
 import type { Triple } from '../../types/rdf'
 import { Search } from 'lucide-react'
 
@@ -11,9 +12,29 @@ const PAGE_SIZE = 100
 export default function TripleTable() {
   const store = useRdfStore((s) => s.store)
   const prefixes = useRdfStore((s) => s.prefixes)
+  const applyStoreChange = useRdfStore((s) => s.applyStoreChange)
   const setSelectedNode = useUiStore((s) => s.setSelectedNode)
+
   const [filter, setFilter] = useState('')
   const [page, setPage] = useState(0)
+
+  // { rowIndex: number, column: string, value: string }
+  const [editingCell, setEditingCell] = useState<{
+    rowIndex: number
+    column: 'subject' | 'predicate' | 'object'
+    value: string
+  } | null>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  // Focus input when editing starts
+  useEffect(() => {
+    if (editingCell && inputRef.current) {
+      inputRef.current.focus()
+      // Optional: place cursor at the end
+      inputRef.current.selectionStart = inputRef.current.value.length
+      inputRef.current.selectionEnd = inputRef.current.value.length
+    }
+  }, [editingCell])
 
   const allTriples = useMemo(() => storeToTriples(store), [store])
 
@@ -35,6 +56,97 @@ export default function TripleTable() {
     if (type === 'literal') return `"${iri}"`
     if (type === 'blank') return `_:${iri}`
     return shorten(iri, prefixes)
+  }
+
+  // Double click handler
+  const handleDoubleClick = (
+    rowIndex: number,
+    column: 'subject' | 'predicate' | 'object',
+    triple: Triple
+  ) => {
+    // Determine the raw value to edit
+    let rawValue = triple[column]
+    if (column === 'object' && triple.objectType === 'literal') {
+      rawValue = triple.object // Edit the literal content directly
+    } else if (triple.objectType === 'blank' && column === 'object') {
+      rawValue = `_:${triple.object}`
+    } else {
+      // For IRIs, if it can be shortened, we let them edit the shortened form
+      rawValue = shorten(triple[column], prefixes)
+    }
+
+    setEditingCell({ rowIndex, column, value: rawValue })
+  }
+
+  const handleSave = async (triple: Triple) => {
+    if (!editingCell) return
+
+    const { column, value } = editingCell
+    setEditingCell(null)
+
+    // Expand if needed
+    const newValue = value.trim()
+    if (!newValue) return // Don't allow empty deletes through inline edit yet
+
+    // Determine type and full IRI/Literal representation
+    let newObject = triple.object
+    let newSubject = triple.subject
+    let newPredicate = triple.predicate
+
+    if (column === 'subject') {
+      newSubject = expand(newValue, prefixes)
+    } else if (column === 'predicate') {
+      newPredicate = expand(newValue, prefixes)
+    } else if (column === 'object') {
+      if (triple.objectType === 'literal') {
+        newObject = newValue
+      } else if (newValue.startsWith('_:')) {
+        newObject = newValue.substring(2)
+      } else {
+        newObject = expand(newValue, prefixes)
+      }
+    }
+
+    // Only update if something changed
+    if (
+      newSubject === triple.subject &&
+      newPredicate === triple.predicate &&
+      newObject === triple.object
+    ) {
+      return
+    }
+
+    const newTriple: Triple = {
+      subject: newSubject,
+      predicate: newPredicate,
+      object: newObject,
+      objectType: triple.objectType, // Keep the same type for now (unless we detect blank node change, but let's keep it simple)
+      language: column === 'object' ? triple.language : undefined,
+      datatype: column === 'object' ? triple.datatype : undefined,
+    }
+
+    // If they changed object to a blank node notation, ensure objectType is updated just in case
+    if (column === 'object' && newValue.startsWith('_:')) {
+      newTriple.objectType = 'blank'
+    } else if (column === 'object' && triple.objectType === 'blank' && !newValue.startsWith('_:')) {
+      // Changing from blank node to IRI
+      newTriple.objectType = 'iri'
+    }
+
+    const changed = updateTriple(store, triple, newTriple)
+    if (changed) {
+      await applyStoreChange()
+    }
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent, triple: Triple) => {
+    if (e.key === 'Enter') {
+      e.stopPropagation()
+      handleSave(triple)
+    } else if (e.key === 'Escape') {
+      e.stopPropagation()
+      setEditingCell(null)
+    }
   }
 
   return (
@@ -71,36 +183,76 @@ export default function TripleTable() {
             {paginated.map((t, i) => (
               <tr
                 key={i}
-                className="border-b border-surface-raised hover:bg-surface-raised cursor-pointer"
-                onClick={() =>
-                  t.objectType === 'iri' ? setSelectedNode(t.object) : setSelectedNode(t.subject)
-                }
+                className="border-b border-surface-raised hover:bg-surface-raised transition-colors"
+                onClick={(e) => {
+                  // Don't select row if we are currently clicking inside an input
+                  if ((e.target as HTMLElement).tagName !== 'INPUT') {
+                    if (t.objectType === 'iri') {
+                      setSelectedNode(t.object)
+                    } else {
+                      setSelectedNode(t.subject)
+                    }
+                  }
+                }}
               >
-                <td className="px-3 py-1 text-accent-blue truncate max-w-0 w-1/3">
-                  <span title={t.subject}>{formatRdfTerm(t.subject)}</span>
-                </td>
-                <td className="px-3 py-1 text-accent-green truncate max-w-0 w-1/3">
-                  <span title={t.predicate}>{formatRdfTerm(t.predicate)}</span>
-                </td>
-                <td className="px-3 py-1 max-w-0 w-1/3">
-                  {t.objectType === 'literal' ? (
-                    <span className="text-accent-yellow truncate block" title={t.object}>
-                      "{t.object}"
-                      {t.language && <span className="text-text-muted ml-1">@{t.language}</span>}
-                      {t.datatype && !t.language && (
-                        <span className="text-text-muted ml-1">
-                          ^^{shorten(t.datatype, prefixes)}
-                        </span>
+                {['subject', 'predicate', 'object'].map((col) => {
+                  const isEditing = editingCell?.rowIndex === i && editingCell?.column === col
+                  const column = col as 'subject' | 'predicate' | 'object'
+
+                  return (
+                    <td
+                      key={col}
+                      className={`px-3 py-1 truncate max-w-0 w-1/3 ${isEditing ? 'p-0' : ''}`}
+                      onDoubleClick={() => !isEditing && handleDoubleClick(i, column, t)}
+                    >
+                      {isEditing ? (
+                        <input
+                          ref={inputRef}
+                          type="text"
+                          className="w-full bg-editor text-text-primary px-2 py-1 outline-none focus:ring-1 focus:ring-accent-blue font-mono text-xs border border-accent-blue rounded-sm"
+                          value={editingCell.value}
+                          onFocus={(e) => e.target.select()}
+                          onChange={(e) =>
+                            setEditingCell({ ...editingCell, value: e.target.value })
+                          }
+                          onBlur={() => handleSave(t)}
+                          onKeyDown={(e) => handleKeyDown(e, t)}
+                        />
+                      ) : (
+                        <div
+                          className={`truncate ${col === 'subject' ? 'text-accent-blue' : col === 'predicate' ? 'text-accent-green' : ''}`}
+                          title={
+                            col === 'object' && t.objectType === 'literal'
+                              ? t.object
+                              : formatRdfTerm(t[column], col === 'object' ? t.objectType : 'iri')
+                          }
+                        >
+                          {col === 'object' ? (
+                            t.objectType === 'literal' ? (
+                              <span className="text-accent-yellow">
+                                "{t.object}"
+                                {t.language && (
+                                  <span className="text-text-muted ml-1">@{t.language}</span>
+                                )}
+                                {t.datatype && !t.language && (
+                                  <span className="text-text-muted ml-1">
+                                    ^^{shorten(t.datatype, prefixes)}
+                                  </span>
+                                )}
+                              </span>
+                            ) : t.objectType === 'blank' ? (
+                              <span className="text-text-muted">_:{t.object}</span>
+                            ) : (
+                              <span className="text-accent-blue">{formatRdfTerm(t.object)}</span>
+                            )
+                          ) : (
+                            <span>{formatRdfTerm(t[column])}</span>
+                          )}
+                        </div>
                       )}
-                    </span>
-                  ) : t.objectType === 'blank' ? (
-                    <span className="text-text-muted">_:{t.object}</span>
-                  ) : (
-                    <span className="text-accent-blue truncate block" title={t.object}>
-                      {formatRdfTerm(t.object)}
-                    </span>
-                  )}
-                </td>
+                    </td>
+                  )
+                })}
               </tr>
             ))}
             {paginated.length === 0 && (

--- a/src/lib/i18n/i18n 2.ts
+++ b/src/lib/i18n/i18n 2.ts
@@ -1,0 +1,33 @@
+import i18n from 'i18next'
+import { initReactI18next } from 'react-i18next'
+import LanguageDetector from 'i18next-browser-languagedetector'
+
+import en from './locales/en.json'
+import ja from './locales/ja.json'
+
+const resources = {
+  en: {
+    translation: en,
+  },
+  ja: {
+    translation: ja,
+  },
+}
+
+i18n
+  // detect user language
+  // learn more: https://github.com/i18next/i18next-browser-languageDetector
+  .use(LanguageDetector)
+  // pass the i18n instance to react-i18next.
+  .use(initReactI18next)
+  // init i18next
+  // for all options read: https://www.i18next.com/overview/configuration-options
+  .init({
+    resources,
+    fallbackLng: 'en',
+    interpolation: {
+      escapeValue: false, // not needed for react as it escapes by default
+    },
+  })
+
+export default i18n

--- a/src/lib/rdf/namespaces.ts
+++ b/src/lib/rdf/namespaces.ts
@@ -51,6 +51,28 @@ export function shorten(iri: string, extra?: Record<string, string>): string {
 }
 
 /**
+ * Expand a shortened prefix:local name back to a full IRI.
+ * Returns the original string if it doesn't match any known prefix.
+ */
+export function expand(shortened: string, extra?: Record<string, string>): string {
+  if (!shortened.includes(':')) return shortened
+
+  const [pfx, local] = shortened.split(':', 2)
+
+  // Check extra prefixes first
+  if (extra && pfx in extra) {
+    return extra[pfx] + local
+  }
+
+  // Check built-in prefixes
+  if (pfx in NS) {
+    return NS[pfx as KnownPrefix] + local
+  }
+
+  return shortened
+}
+
+/**
  * Extract the local name from a full IRI (after the last '#' or '/').
  * Returns the full IRI if no separator is found.
  */

--- a/src/store/rdfStore.ts
+++ b/src/store/rdfStore.ts
@@ -123,5 +123,8 @@ export const useRdfStore = create<RdfState>((set, get) => ({
     const { store, prefixes } = get()
     const turtle = await serializeTurtle(store, prefixes)
     set({ turtleText: turtle })
+    // Reparse the newly generated Turtle to replace the store with a new instance,
+    // which triggers React's state change detection and invalidates memoized lists.
+    await get().reparseNow()
   },
 }))

--- a/tests/e2e/i18n.spec 2.ts
+++ b/tests/e2e/i18n.spec 2.ts
@@ -1,0 +1,58 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Internationalization (i18n)', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto('/');
+        // Wait for app to load initially
+        await expect(page.getByRole('button', { name: /Editor|エディタ/i })).toBeVisible();
+    });
+
+    test('switches language between English and Japanese', async ({ page }) => {
+        // Find the language toggle button. It should initially display "JA" when in English, or "EN" when in Japanese.
+        // The default fallback is English, but browser language might be Japanese.
+        const langToggle = page.getByTitle('Toggle Language');
+        await expect(langToggle).toBeVisible();
+
+        let initialLang = await langToggle.textContent();
+        initialLang = initialLang?.trim() || '';
+
+        if (initialLang === 'JA') {
+            // Currently in English, should see "Editor"
+            await expect(page.getByRole('button', { name: 'Editor', exact: true })).toBeVisible();
+            await expect(page.getByRole('button', { name: 'Graph', exact: true })).toBeVisible();
+            await expect(page.getByRole('button', { name: 'Table', exact: true })).toBeVisible();
+            await expect(page.getByRole('button', { name: 'Split', exact: true })).toBeVisible();
+
+            // Toggle to Japanese
+            await langToggle.click();
+
+            // Now we should see "エディタ" and the toggle should say "EN"
+            await expect(page.getByRole('button', { name: 'エディタ', exact: true })).toBeVisible();
+            await expect(page.getByRole('button', { name: 'グラフ', exact: true })).toBeVisible();
+            await expect(page.getByRole('button', { name: 'テーブル', exact: true })).toBeVisible();
+            await expect(page.getByRole('button', { name: '分割表示', exact: true })).toBeVisible();
+
+            await expect(langToggle).toHaveText('EN');
+
+            // Toggle back to English
+            await langToggle.click();
+            await expect(page.getByRole('button', { name: 'Editor', exact: true })).toBeVisible();
+            await expect(langToggle).toHaveText('JA');
+        } else {
+            // Currently in Japanese, should see "エディタ"
+            await expect(page.getByRole('button', { name: 'エディタ', exact: true })).toBeVisible();
+
+            // Toggle to English
+            await langToggle.click();
+
+            // Now we should see "Editor" and the toggle should say "JA"
+            await expect(page.getByRole('button', { name: 'Editor', exact: true })).toBeVisible();
+            await expect(langToggle).toHaveText('JA');
+
+            // Toggle back to Japanese
+            await langToggle.click();
+            await expect(page.getByRole('button', { name: 'エディタ', exact: true })).toBeVisible();
+            await expect(langToggle).toHaveText('EN');
+        }
+    });
+});

--- a/tests/e2e/table-editing.spec.ts
+++ b/tests/e2e/table-editing.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Table Inline Editing', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto('/');
+
+        // Wait for editor to load
+        await expect(page.locator('.monaco-editor')).toBeVisible();
+
+        // Switch to Table view
+        const tableButton = page.getByRole('button', { name: /Table|テーブル/i });
+        await tableButton.click();
+
+        // Ensure table is loaded and shows default FOAF triples.
+        // Note: http://example.org/alice is shortened to "alice" by the formatRdfTerm logic since it has no prefix.
+        await expect(page.getByText('alice', { exact: true }).first()).toBeVisible();
+        await expect(page.getByText('foaf:name', { exact: true }).first()).toBeVisible();
+        await expect(page.getByText(/"Alice"/)).toBeVisible();
+    });
+
+    test('should allow editing an object literal via double click', async ({ page }) => {
+        // Double click the object cell "Alice"
+        const objectCell = page.getByRole('cell', { name: /"Alice"/ });
+        await objectCell.dblclick();
+
+        // An input should appear. Type new value and press Enter.
+        const input = page.locator('td input[type="text"]');
+        await expect(input).toBeVisible();
+        await expect(input).toHaveValue('Alice');
+
+        await input.fill('Alice Liddell');
+        await input.press('Enter');
+
+        // Input should disappear, new value should be displayed
+        await expect(input).not.toBeVisible();
+        await expect(page.getByText(/"Alice Liddell"/)).toBeVisible();
+
+        // Switch back to editor to verify it got synced
+        const editorButton = page.getByRole('button', { name: /Editor|エディタ/i });
+        await editorButton.click();
+
+        // Use evaluate to get the actual Monaco model value
+        const editorText = await page.evaluate(() => {
+            // @ts-ignore
+            return window.monaco.editor.getModels()[0].getValue();
+        });
+        expect(editorText).toContain('"Alice Liddell"');
+        expect(editorText).not.toContain('"Alice" ;');
+    });
+
+    test('should allow editing a subject IRI via double click', async ({ page }) => {
+        // Find the cell with alice (first occurrence)
+        const subjectCell = page.getByText('alice', { exact: true }).first();
+        await subjectCell.dblclick();
+
+        const input = page.locator('td input[type="text"]');
+        // Let's change it to http://example.org/alicia
+        await input.fill('http://example.org/alicia');
+
+        // Test blur save by clicking another cell
+        await page.getByText('foaf:name', { exact: true }).first().click();
+
+        await expect(input).not.toBeVisible();
+        // It will be shortened to alicia
+        await expect(page.getByText('alicia', { exact: true }).first()).toBeVisible();
+    });
+
+    test('should cancel editing on Escape', async ({ page }) => {
+        const predicateCell = page.getByText('foaf:name', { exact: true }).first();
+        await predicateCell.dblclick();
+
+        const input = page.locator('td input[type="text"]');
+        await input.fill('foaf:givenName');
+        await input.press('Escape');
+
+        // Should revert to old value
+        await expect(input).not.toBeVisible();
+        await expect(page.getByText('foaf:name', { exact: true }).first()).toBeVisible();
+        await expect(page.getByText('foaf:givenName')).not.toBeVisible();
+    });
+});


### PR DESCRIPTION
Implements inline table editing capabilities as requested in A-2. Allows users to double-click Subject, Predicate, and Object cells to edit them directly.