### PR TITLE
Add structured parse error reporting with line/column info

### DIFF
--- a/src/components/editor/TurtleEditor.tsx
+++ b/src/components/editor/TurtleEditor.tsx
@@ -11,7 +11,7 @@ import {
   disposeCompletionProvider,
 } from '../../lib/editor/completionProvider'
 import {
-  fromParseError,
+  fromParseErrors,
   setDiagnostics,
   applyDiagnostics,
   clearDiagnostics,
@@ -21,6 +21,7 @@ export default function TurtleEditor() {
   const turtleText = useRdfStore((s) => s.turtleText)
   const setTurtleText = useRdfStore((s) => s.setTurtleText)
   const parseError = useRdfStore((s) => s.parseError)
+  const parseErrors = useRdfStore((s) => s.parseErrors)
   const isParsing = useRdfStore((s) => s.isParsing)
   const editorRef = useRef<MonacoEditor.editor.IStandaloneCodeEditor | null>(null)
   const monacoRef = useRef<Monaco | null>(null)
@@ -34,7 +35,7 @@ export default function TurtleEditor() {
     const model = editor.getModel()
     if (!model) return
 
-    const diagnostics = fromParseError(parseError)
+    const diagnostics = fromParseErrors(parseErrors)
     setDiagnostics(diagnostics)
 
     if (diagnostics.length > 0) {
@@ -42,7 +43,7 @@ export default function TurtleEditor() {
     } else {
       clearDiagnostics(monaco, model)
     }
-  }, [parseError])
+  }, [parseErrors])
 
   // Cleanup completion provider on unmount
   useEffect(() => {

--- a/src/lib/editor/__tests__/providers.test.ts
+++ b/src/lib/editor/__tests__/providers.test.ts
@@ -7,7 +7,13 @@ import {
 } from '../completionProvider'
 import type { Monaco } from '@monaco-editor/react'
 import type * as MonacoEditor from 'monaco-editor'
-import { fromParseError, setDiagnostics, getDiagnostics } from '../diagnosticsProvider'
+import {
+  fromParseError,
+  fromParseErrors,
+  setDiagnostics,
+  getDiagnostics,
+} from '../diagnosticsProvider'
+import type { ParseError } from '../../rdf/parser'
 
 // ─── Completion Provider Tests ────────────────────────────────────
 
@@ -162,6 +168,49 @@ describe('diagnosticsProvider', () => {
       setDiagnostics([{ message: 'b', severity: 'warning' }])
       expect(getDiagnostics()).toHaveLength(1)
       expect(getDiagnostics()[0].message).toBe('b')
+    })
+  })
+
+  describe('fromParseErrors', () => {
+    it('returns empty array for empty input', () => {
+      expect(fromParseErrors([])).toEqual([])
+    })
+
+    it('converts a single ParseError to DiagnosticItem', () => {
+      const errors: ParseError[] = [
+        { message: 'Unexpected token on line 5.', severity: 'error', line: 5, column: 3 },
+      ]
+      const diagnostics = fromParseErrors(errors)
+      expect(diagnostics).toHaveLength(1)
+      expect(diagnostics[0].message).toBe('Unexpected token on line 5.')
+      expect(diagnostics[0].severity).toBe('error')
+      expect(diagnostics[0].line).toBe(5)
+      expect(diagnostics[0].startColumn).toBe(3)
+      expect(diagnostics[0].source).toBe('parser')
+    })
+
+    it('converts multiple ParseErrors to DiagnosticItems', () => {
+      const errors: ParseError[] = [
+        { message: 'Error on line 2.', severity: 'error', line: 2, column: 1 },
+        { message: 'Warning on line 7.', severity: 'warning', line: 7, column: 5 },
+        { message: 'Info on line 10.', severity: 'info', line: 10, column: 1 },
+      ]
+      const diagnostics = fromParseErrors(errors)
+      expect(diagnostics).toHaveLength(3)
+      expect(diagnostics[0].severity).toBe('error')
+      expect(diagnostics[1].severity).toBe('warning')
+      expect(diagnostics[2].severity).toBe('info')
+      expect(diagnostics[1].line).toBe(7)
+      expect(diagnostics[1].startColumn).toBe(5)
+    })
+
+    it('preserves all severity levels', () => {
+      const severities = ['error', 'warning', 'info'] as const
+      for (const severity of severities) {
+        const errors: ParseError[] = [{ message: 'msg', severity, line: 1, column: 1 }]
+        const diagnostics = fromParseErrors(errors)
+        expect(diagnostics[0].severity).toBe(severity)
+      }
     })
   })
 })

--- a/src/lib/editor/diagnosticsProvider.ts
+++ b/src/lib/editor/diagnosticsProvider.ts
@@ -9,6 +9,7 @@
  */
 import type { Monaco } from '@monaco-editor/react'
 import type * as MonacoEditor from 'monaco-editor'
+import type { ParseError } from '../rdf/parser'
 
 /** Sentinel column used to highlight errors to end-of-line. */
 const END_OF_LINE_COLUMN = 9999
@@ -41,6 +42,8 @@ let currentDiagnostics: DiagnosticItem[] = []
 /**
  * Create a diagnostic from a parse error string.
  * Extracts line number from common parse error patterns.
+ *
+ * @deprecated Prefer `fromParseErrors` which uses structured ParseError objects.
  */
 export function fromParseError(error: string | null): DiagnosticItem[] {
   if (!error) return []
@@ -57,6 +60,20 @@ export function fromParseError(error: string | null): DiagnosticItem[] {
       source: 'parser',
     },
   ]
+}
+
+/**
+ * Convert an array of structured ParseError objects into DiagnosticItems.
+ * Preserves precise line/column information from the parser.
+ */
+export function fromParseErrors(errors: ParseError[]): DiagnosticItem[] {
+  return errors.map((e) => ({
+    message: e.message,
+    severity: e.severity,
+    line: e.line,
+    startColumn: e.column,
+    source: 'parser',
+  }))
 }
 
 /**

--- a/src/lib/rdf/__tests__/parser.test.ts
+++ b/src/lib/rdf/__tests__/parser.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { parseTurtle, parseNTriples, parseJsonLd, parseAuto } from '../parser'
+import type { ParseError } from '../parser'
 
 const VALID_TURTLE = `
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
@@ -45,6 +46,37 @@ describe('parseTurtle', () => {
     expect(result.error).toBeUndefined()
     expect(result.store.size).toBe(0)
     expect(result.prefixes).toHaveProperty('rdf')
+  })
+
+  it('returns empty errors array for valid Turtle', async () => {
+    const result = await parseTurtle(VALID_TURTLE)
+    expect(result.errors).toBeDefined()
+    expect(result.errors).toHaveLength(0)
+  })
+
+  it('returns structured errors array for invalid Turtle', async () => {
+    const result = await parseTurtle(INVALID_TURTLE)
+    expect(result.errors).toBeDefined()
+    const errors = result.errors ?? []
+    expect(errors.length).toBeGreaterThan(0)
+    const err: ParseError = errors[0]
+    expect(err.severity).toBe('error')
+    expect(err.message).toBeTruthy()
+    expect(err.line).toBeGreaterThanOrEqual(1)
+    expect(err.column).toBeGreaterThanOrEqual(1)
+  })
+
+  it('extracts precise line number from N3 error context', async () => {
+    const turtle = `@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+<http://example.org/alice> foaf:name "Alice" .
+<http://example.org/bob> foaf:name INVALID_TOKEN .
+`
+    const result = await parseTurtle(turtle)
+    expect(result.errors).toBeDefined()
+    const errors = result.errors ?? []
+    expect(errors.length).toBeGreaterThan(0)
+    // Error should be on line 3 where INVALID_TOKEN appears
+    expect(errors[0].line).toBe(3)
   })
 })
 

--- a/src/lib/rdf/parser.ts
+++ b/src/lib/rdf/parser.ts
@@ -2,10 +2,59 @@ import * as N3 from 'n3'
 import type { RdfFormat } from '../../types/rdf'
 import type * as JsonLdModule from 'jsonld'
 
+/** Severity level for a parse error. */
+export type ParseErrorSeverity = 'error' | 'warning' | 'info'
+
+/** Structured representation of a single parse error with location information. */
+export interface ParseError {
+  /** Human-readable error message. */
+  message: string
+  /** Severity level. */
+  severity: ParseErrorSeverity
+  /** 1-based line number where the error occurred. */
+  line: number
+  /** 1-based column number where the error occurred. Defaults to 1. */
+  column: number
+}
+
 export interface ParseResult {
   store: N3.Store
   prefixes: Record<string, string>
+  /** @deprecated Use `errors` for structured error information. */
   error?: string
+  /** Structured list of parse errors with location information. */
+  errors?: ParseError[]
+}
+
+/** N3 error context shape attached to N3 parser errors. */
+interface N3ErrorContext {
+  line?: number
+  token?: unknown
+  previousToken?: unknown
+}
+
+/**
+ * Extract a structured ParseError from an N3 parser error.
+ * N3 errors expose `error.context.line` for the line number.
+ */
+function toParseError(error: Error): ParseError {
+  const ctx = (error as Error & { context?: N3ErrorContext }).context
+  const line = ctx?.line ?? extractLineFromMessage(error.message)
+  return {
+    message: error.message,
+    severity: 'error',
+    line,
+    column: 1,
+  }
+}
+
+/**
+ * Fallback: extract a line number from an error message string.
+ * Handles patterns like "on line 5" or "Line 5".
+ */
+function extractLineFromMessage(message: string): number {
+  const match = message.match(/line (\d+)/i)
+  return match ? parseInt(match[1], 10) : 1
 }
 
 /**
@@ -19,7 +68,8 @@ export function parseTurtle(text: string): Promise<ParseResult> {
 
     parser.parse(text, (error, quad, prefixMap) => {
       if (error) {
-        resolve({ store, prefixes, error: error.message })
+        const parseError = toParseError(error)
+        resolve({ store, prefixes, error: error.message, errors: [parseError] })
         return
       }
       if (quad) {
@@ -34,7 +84,7 @@ export function parseTurtle(text: string): Promise<ParseResult> {
             ])
           )
         }
-        resolve({ store, prefixes })
+        resolve({ store, prefixes, errors: [] })
       }
     })
   })
@@ -53,13 +103,14 @@ export function parseNTriples(
 
     parser.parse(text, (error, quad) => {
       if (error) {
-        resolve({ store, prefixes: {}, error: error.message })
+        const parseError = toParseError(error)
+        resolve({ store, prefixes: {}, error: error.message, errors: [parseError] })
         return
       }
       if (quad) {
         store.add(quad)
       } else {
-        resolve({ store, prefixes: {} })
+        resolve({ store, prefixes: {}, errors: [] })
       }
     })
   })
@@ -79,7 +130,13 @@ export async function parseJsonLd(text: string): Promise<ParseResult> {
     })) as string
     return parseNTriples(nquads, 'N-Quads')
   } catch (err) {
-    return { store: new N3.Store(), prefixes: {}, error: String(err) }
+    const message = String(err)
+    return {
+      store: new N3.Store(),
+      prefixes: {},
+      error: message,
+      errors: [{ message, severity: 'error', line: 1, column: 1 }],
+    }
   }
 }
 

--- a/src/store/rdfStore.ts
+++ b/src/store/rdfStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import * as N3 from 'n3'
 import { parseTurtle, parseNTriples, parseJsonLd } from '../lib/rdf/parser'
+import type { ParseError } from '../lib/rdf/parser'
 import { serializeTurtle, serializeNTriples, downloadText } from '../lib/rdf/serializer'
 import type { RdfFormat } from '../types/rdf'
 import type * as JsonLdModule from 'jsonld'
@@ -10,7 +11,10 @@ export interface RdfState {
   turtleText: string
   store: N3.Store
   prefixes: Record<string, string>
+  /** @deprecated Use `parseErrors` for structured error information. */
   parseError: string | null
+  /** Structured list of parse errors with location information. */
+  parseErrors: ParseError[]
   isParsing: boolean
 
   // Actions
@@ -27,6 +31,8 @@ export interface RdfState {
   applyStoreChange: () => Promise<void>
 }
 
+export type { ParseError }
+
 // Debounce timer for auto-parse
 let parseTimer: ReturnType<typeof setTimeout> | null = null
 
@@ -40,6 +46,7 @@ async function applyParseResult(
     store: result.store,
     prefixes: result.prefixes,
     parseError: result.error ?? null,
+    parseErrors: result.errors ?? [],
     isParsing: false,
   })
 }
@@ -49,10 +56,11 @@ export const useRdfStore = create<RdfState>((set, get) => ({
   store: new N3.Store(),
   prefixes: {},
   parseError: null,
+  parseErrors: [],
   isParsing: false,
 
   setTurtleText: (text) => {
-    set({ turtleText: text, parseError: null })
+    set({ turtleText: text, parseError: null, parseErrors: [] })
     // Debounce parsing: 400ms after last keystroke
     if (parseTimer) clearTimeout(parseTimer)
     parseTimer = setTimeout(() => applyParseResult(text, set), 400)
@@ -79,7 +87,7 @@ export const useRdfStore = create<RdfState>((set, get) => ({
     }
 
     if (parseResult.error) {
-      set({ parseError: parseResult.error })
+      set({ parseError: parseResult.error, parseErrors: parseResult.errors ?? [] })
       return
     }
 
@@ -116,13 +124,13 @@ export const useRdfStore = create<RdfState>((set, get) => ({
   },
 
   clearAll: () => {
-    set({ turtleText: '', store: new N3.Store(), prefixes: {}, parseError: null })
+    set({ turtleText: '', store: new N3.Store(), prefixes: {}, parseError: null, parseErrors: [] })
   },
 
   applyStoreChange: async () => {
     const { store, prefixes } = get()
     const turtle = await serializeTurtle(store, prefixes)
-    set({ turtleText: turtle, parseError: null })
+    set({ turtleText: turtle, parseError: null, parseErrors: [] })
     // Reparse the newly generated Turtle to replace the store with a new instance,
     // which triggers React's state change detection and invalidates memoized lists.
     await get().reparseNow()


### PR DESCRIPTION
## Summary
This PR enhances error reporting in the RDF parser by introducing structured `ParseError` objects with precise location information (line and column numbers), replacing the previous string-based error handling. This enables better error visualization in the editor with accurate diagnostic positioning.

## Key Changes

- **New `ParseError` interface** in `parser.ts`: Structured error representation with `message`, `severity` ('error' | 'warning' | 'info'), `line`, and `column` fields
- **Error extraction utilities**: Added `toParseError()` and `extractLineFromMessage()` functions to convert N3 parser errors into structured `ParseError` objects, with fallback line number extraction from error messages
- **Updated `ParseResult` interface**: Added `errors?: ParseError[]` field alongside the deprecated `error?: string` field for backward compatibility
- **Parser updates**: Modified `parseTurtle()`, `parseNTriples()`, and `parseJsonLd()` to populate the new `errors` array in addition to the legacy `error` field
- **New `fromParseErrors()` function** in `diagnosticsProvider.ts`: Converts structured `ParseError` objects to Monaco editor `DiagnosticItem` objects, preserving severity levels and precise positioning
- **Store integration**: Updated `rdfStore.ts` to track `parseErrors: ParseError[]` alongside the deprecated `parseError` field, ensuring state consistency across the application
- **Editor component update**: Modified `TurtleEditor.tsx` to use the new `fromParseErrors()` function with structured error data instead of the legacy string-based approach
- **Comprehensive test coverage**: Added tests for error extraction, structured error conversion, and precise line number detection

## Notable Implementation Details

- N3 parser errors are inspected for `context.line` property to extract precise line numbers
- Fallback regex pattern matching handles error messages that include line information
- All severity levels ('error', 'warning', 'info') are preserved through the conversion pipeline
- Backward compatibility maintained with deprecated `error` field in both `ParseResult` and `RdfState`
- Column numbers default to 1 when not available from the parser

https://claude.ai/code/session_011aduXtCbJDLKF1hZ43QoV1