### PR TITLE
fix(ui): remove hover gap in dropdown menus

### DIFF
--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -219,25 +219,27 @@ export default function AppLayout() {
               <FileDown size={13} />
               <span className="hidden sm:inline">{t('layout.export')}</span>
             </button>
-            <div className="hidden group-hover:flex flex-col absolute right-0 top-full mt-1 bg-surface-raised border border-surface-raised rounded shadow-lg z-50 min-w-36">
-              <button
-                onClick={() => exportAs('turtle')}
-                className="px-3 py-2 text-xs text-left hover:bg-surface text-text-primary"
-              >
-                Turtle (.ttl)
-              </button>
-              <button
-                onClick={() => exportAs('n-triples')}
-                className="px-3 py-2 text-xs text-left hover:bg-surface text-text-primary"
-              >
-                N-Triples (.nt)
-              </button>
-              <button
-                onClick={() => exportAs('jsonld')}
-                className="px-3 py-2 text-xs text-left hover:bg-surface text-text-primary"
-              >
-                JSON-LD (.jsonld)
-              </button>
+            <div className="hidden group-hover:flex flex-col absolute right-0 top-full pt-1 z-50 min-w-36">
+              <div className="flex flex-col bg-surface-raised border border-surface-raised rounded shadow-lg overflow-hidden">
+                <button
+                  onClick={() => exportAs('turtle')}
+                  className="px-3 py-2 text-xs text-left hover:bg-surface text-text-primary"
+                >
+                  Turtle (.ttl)
+                </button>
+                <button
+                  onClick={() => exportAs('n-triples')}
+                  className="px-3 py-2 text-xs text-left hover:bg-surface text-text-primary"
+                >
+                  N-Triples (.nt)
+                </button>
+                <button
+                  onClick={() => exportAs('jsonld')}
+                  className="px-3 py-2 text-xs text-left hover:bg-surface text-text-primary"
+                >
+                  JSON-LD (.jsonld)
+                </button>
+              </div>
             </div>
           </div>
 

--- a/src/components/layout/TemplateMenu.tsx
+++ b/src/components/layout/TemplateMenu.tsx
@@ -13,38 +13,40 @@ export default function TemplateMenu() {
         <BookOpen size={13} />
         <span className="hidden sm:inline">Examples</span>
       </button>
-      <div className="hidden group-hover:flex flex-col absolute right-0 top-full mt-1 bg-surface-raised border border-surface-raised rounded shadow-lg z-50 min-w-44">
-        {domainList.map((domain) => (
-          <div key={domain.id} className="relative group/sub">
-            <div className="flex items-center justify-between px-3 py-2 text-xs text-text-primary hover:bg-surface cursor-default">
-              <span className="font-medium">{domain.label}</span>
-              {domain.templates.length > 1 && (
-                <ChevronRight size={11} className="text-text-muted" />
-              )}
-            </div>
-            {domain.templates.length === 1 ? (
-              <button
-                onClick={() => loadTemplate(domain.id, domain.templates[0].id)}
-                className="w-full px-5 py-1.5 text-xs text-left hover:bg-surface text-text-muted"
-              >
-                {domain.templates[0].label}
-              </button>
-            ) : (
-              domain.templates.map((tmpl) => (
+      <div className="hidden group-hover:flex flex-col absolute right-0 top-full pt-1 z-50 min-w-44">
+        <div className="flex flex-col bg-surface-raised border border-surface-raised rounded shadow-lg">
+          {domainList.map((domain) => (
+            <div key={domain.id} className="relative group/sub">
+              <div className="flex items-center justify-between px-3 py-2 text-xs text-text-primary hover:bg-surface cursor-default">
+                <span className="font-medium">{domain.label}</span>
+                {domain.templates.length > 1 && (
+                  <ChevronRight size={11} className="text-text-muted" />
+                )}
+              </div>
+              {domain.templates.length === 1 ? (
                 <button
-                  key={tmpl.id}
-                  onClick={() => loadTemplate(domain.id, tmpl.id)}
+                  onClick={() => loadTemplate(domain.id, domain.templates[0].id)}
                   className="w-full px-5 py-1.5 text-xs text-left hover:bg-surface text-text-muted"
                 >
-                  {tmpl.label}
+                  {domain.templates[0].label}
                 </button>
-              ))
-            )}
-            {domain.id !== domainList[domainList.length - 1].id && (
-              <div className="border-b border-surface mx-2" />
-            )}
-          </div>
-        ))}
+              ) : (
+                domain.templates.map((tmpl) => (
+                  <button
+                    key={tmpl.id}
+                    onClick={() => loadTemplate(domain.id, tmpl.id)}
+                    className="w-full px-5 py-1.5 text-xs text-left hover:bg-surface text-text-muted"
+                  >
+                    {tmpl.label}
+                  </button>
+                ))
+              )}
+              {domain.id !== domainList[domainList.length - 1].id && (
+                <div className="border-b border-surface mx-2" />
+              )}
+            </div>
+          ))}
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
Fixes an issue where dropdown menus close unexpectedly if the cursor is moved slowly, as the margin was not triggering the hover state. Replaced margins with an invisible padding bridge.